### PR TITLE
Move sip_ua and hide internals

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -3,7 +3,7 @@ import 'package:flutter/foundation.dart'
     show debugDefaultTargetPlatformOverride;
 
 import 'package:flutter/material.dart';
-import 'src/sip_ua_helper.dart';
+import 'package:sip_ua/sip_ua.dart';
 import 'src/register.dart';
 import 'src/dialpad.dart';
 import 'src/callscreen.dart';

--- a/example/lib/src/callscreen.dart
+++ b/example/lib/src/callscreen.dart
@@ -145,7 +145,7 @@ class _MyCallScreenWidget extends State<CallScreenWidget>
   }
 
   @override
-  void registrationStateChanged(RegistrationStateEnum state) {
+  void registrationStateChanged(RegistrationStateEnum state, String cause) {
     //NO OP
   }
   void _backToDialPad() {

--- a/example/lib/src/callscreen.dart
+++ b/example/lib/src/callscreen.dart
@@ -1,12 +1,9 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_webrtc/webrtc.dart';
-import 'package:sip_ua/src/RTCSession.dart';
-import 'package:sip_ua/src/NameAddrHeader.dart';
-import 'package:sip_ua/src/event_manager/event_manager.dart';
 
 import 'widgets/action_button.dart';
-import 'sip_ua_helper.dart';
+import 'package:sip_ua/sip_ua.dart';
 
 class CallScreenWidget extends StatefulWidget {
   final SIPUAHelper _helper;
@@ -15,7 +12,8 @@ class CallScreenWidget extends StatefulWidget {
   _MyCallScreenWidget createState() => _MyCallScreenWidget();
 }
 
-class _MyCallScreenWidget extends State<CallScreenWidget> {
+class _MyCallScreenWidget extends State<CallScreenWidget>
+    implements SipUaHelperListener {
   RTCVideoRenderer _localRenderer = RTCVideoRenderer();
   RTCVideoRenderer _remoteRenderer = RTCVideoRenderer();
   double _localVideoHeight;
@@ -23,9 +21,7 @@ class _MyCallScreenWidget extends State<CallScreenWidget> {
   EdgeInsetsGeometry _localVideoMargin;
   MediaStream _localStream;
   MediaStream _remoteStream;
-  String _direction;
-  NameAddrHeader _local_identity;
-  NameAddrHeader _remote_identity;
+
   bool _showNumPad = false;
 
   String _timeLabel = '00:00';
@@ -36,9 +32,7 @@ class _MyCallScreenWidget extends State<CallScreenWidget> {
   bool _speakerOn = false;
   bool _hold = false;
   String _holdOriginator;
-  String _state = 'new';
-
-  RTCSession get session => helper.session;
+  CallStateEnum _state = CallStateEnum.NONE;
 
   SIPUAHelper get helper => widget._helper;
 
@@ -46,24 +40,22 @@ class _MyCallScreenWidget extends State<CallScreenWidget> {
       (_localStream == null || _localStream.getVideoTracks().isEmpty) &&
       (_remoteStream == null || _remoteStream.getVideoTracks().isEmpty);
 
-  String get remote_identity =>
-      _remote_identity.display_name ?? _remote_identity.uri.user;
+  String get remote_identity => helper.remote_identity;
+
+  String get direction => helper.direction;
 
   @override
   initState() {
     super.initState();
     _initRenderers();
-    _bindEventListeners();
+    helper.addSipUaHelperListener(this);
     _startTimer();
-    _direction = session.direction.toUpperCase();
-    _local_identity = session.local_identity;
-    _remote_identity = session.remote_identity;
   }
 
   @override
   deactivate() {
     super.deactivate();
-    _removeEventListeners();
+    helper.removeSipUaHelperListener(this);
     _disposeRenderers();
   }
 
@@ -102,55 +94,60 @@ class _MyCallScreenWidget extends State<CallScreenWidget> {
     }
   }
 
-  void _bindEventListeners() {
-    helper.on(EventCallState(), _handleCalllState);
-  }
-
-  void _handleCalllState(EventCallState data) {
-    if (data.state == 'hold' || data.state == 'unhold') {
-      _hold = data.state == 'hold';
-      _holdOriginator = data.originator;
+  @override
+  void callStateChanged(CallState callState) {
+    if (callState.state == CallStateEnum.HOLD ||
+        callState.state == CallStateEnum.UNHOLD) {
+      _hold = callState.state == CallStateEnum.HOLD;
+      _holdOriginator = callState.originator;
       this.setState(() {});
       return;
     }
 
-    if (data.state == 'muted') {
-      if (data.audio) _audioMuted = true;
-      if (data.video) _videoMuted = true;
+    if (callState.state == CallStateEnum.MUTED) {
+      if (callState.audio) _audioMuted = true;
+      if (callState.video) _videoMuted = true;
       this.setState(() {});
       return;
     }
 
-    if (data.state == 'unmuted') {
-      if (data.audio) _audioMuted = false;
-      if (data.video) _videoMuted = false;
+    if (callState.state == CallStateEnum.UNMUTED) {
+      if (callState.audio) _audioMuted = false;
+      if (callState.video) _videoMuted = false;
       this.setState(() {});
       return;
     }
 
-    if (data.state != 'stream') {
-      _state = data.state;
+    if (callState.state != CallStateEnum.STREAM) {
+      _state = callState.state;
     }
 
-    switch (data.state) {
-      case 'stream':
-        _handelStreams(data);
+    switch (callState.state) {
+      case CallStateEnum.STREAM:
+        _handelStreams(callState);
         break;
-      case 'progress':
-      case 'connecting':
-      case 'confirmed':
-        break;
-      case 'ended':
-      case 'failed':
+      case CallStateEnum.ENDED:
+      case CallStateEnum.FAILED:
         _backToDialPad();
         break;
+      case CallStateEnum.UNMUTED:
+      case CallStateEnum.MUTED:
+      case CallStateEnum.CONNECTING:
+      case CallStateEnum.PROGRESS:
+      case CallStateEnum.ACCEPTED:
+      case CallStateEnum.CONFIRMED:
+      case CallStateEnum.HOLD:
+      case CallStateEnum.UNHOLD:
+      case CallStateEnum.NONE:
+      case CallStateEnum.CALL_INITIATION:
+        break;
     }
   }
 
-  void _removeEventListeners() {
-    helper.remove(EventCallState(), _handleCalllState);
+  @override
+  void registrationStateChanged(RegistrationStateEnum state) {
+    //NO OP
   }
-
   void _backToDialPad() {
     _timer.cancel();
     Timer(Duration(seconds: 2), () {
@@ -158,7 +155,7 @@ class _MyCallScreenWidget extends State<CallScreenWidget> {
     });
   }
 
-  void _handelStreams(EventCallState event) async {
+  void _handelStreams(CallState event) async {
     var stream = event.stream;
     if (event.originator == 'local') {
       if (_localRenderer != null) {
@@ -264,9 +261,9 @@ class _MyCallScreenWidget extends State<CallScreenWidget> {
     var advanceActions = <Widget>[];
 
     switch (_state) {
-      case 'new':
-      case 'connecting':
-        if (_direction == 'INCOMING') {
+      case CallStateEnum.NONE:
+      case CallStateEnum.CONNECTING:
+        if (direction == 'INCOMING') {
           basicActions.add(ActionButton(
             title: "Accept",
             fillColor: Colors.green,
@@ -278,8 +275,8 @@ class _MyCallScreenWidget extends State<CallScreenWidget> {
           basicActions.add(hangupBtn);
         }
         break;
-      case 'accepted':
-      case 'confirmed':
+      case CallStateEnum.ACCEPTED:
+      case CallStateEnum.CONFIRMED:
         {
           advanceActions.add(ActionButton(
             title: _audioMuted ? 'unmute' : 'mute',
@@ -334,11 +331,11 @@ class _MyCallScreenWidget extends State<CallScreenWidget> {
           ));
         }
         break;
-      case 'failed':
-      case 'ended':
+      case CallStateEnum.FAILED:
+      case CallStateEnum.ENDED:
         basicActions.add(hangupBtnInactive);
         break;
-      case 'progress':
+      case CallStateEnum.PROGRESS:
         basicActions.add(hangupBtn);
         break;
       default:
@@ -441,7 +438,7 @@ class _MyCallScreenWidget extends State<CallScreenWidget> {
     return Scaffold(
         appBar: AppBar(
             automaticallyImplyLeading: false,
-            title: Text('[$_direction] ${_state}')),
+            title: Text('[$direction] ${EnumHelper.getName(_state)}')),
         body: Container(
           child: _buildContent(),
         ),

--- a/example/lib/src/dialpad.dart
+++ b/example/lib/src/dialpad.dart
@@ -210,7 +210,7 @@ class _MyDialPadWidget extends State<DialPadWidget>
   }
 
   @override
-  void registrationStateChanged(RegistrationStateEnum state) {
+  void registrationStateChanged(RegistrationStateEnum state, String cause) {
     this.setState(() {});
   }
 

--- a/example/lib/src/dialpad.dart
+++ b/example/lib/src/dialpad.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'sip_ua_helper.dart';
+
 import 'widgets/numpad.dart';
-import 'package:sip_ua/src/event_manager/event_manager.dart';
+import 'package:sip_ua/sip_ua.dart';
 
 class DialPadWidget extends StatefulWidget {
   final SIPUAHelper _helper;
@@ -11,7 +11,8 @@ class DialPadWidget extends StatefulWidget {
   _MyDialPadWidget createState() => _MyDialPadWidget();
 }
 
-class _MyDialPadWidget extends State<DialPadWidget> {
+class _MyDialPadWidget extends State<DialPadWidget>
+    implements SipUaHelperListener {
   String _dest;
   SIPUAHelper get helper => widget._helper;
   TextEditingController _textController;
@@ -33,14 +34,7 @@ class _MyDialPadWidget extends State<DialPadWidget> {
   }
 
   void _bindEventListeners() {
-    helper.on(EventRegisterState(), (EventRegisterState data) {
-      this.setState(() {});
-    });
-    helper.on(EventUaState(), (EventUaState data) {
-      if (data.state == 'newRTCSession') {
-        Navigator.pushNamed(context, '/callscreen');
-      }
-    });
+    helper.addSipUaHelperListener(this);
   }
 
   Widget _handleCall(BuildContext context, [bool voiceonly = false]) {
@@ -202,7 +196,7 @@ class _MyDialPadWidget extends State<DialPadWidget> {
                     padding: const EdgeInsets.all(6.0),
                     child: Center(
                         child: Text(
-                      'Status: ${helper.registerState}',
+                      'Status: ${EnumHelper.getName(helper.registerState)}',
                       style: TextStyle(fontSize: 14, color: Colors.black54),
                     )),
                   ),
@@ -213,5 +207,17 @@ class _MyDialPadWidget extends State<DialPadWidget> {
                     children: _buildDialPad(),
                   )),
                 ])));
+  }
+
+  @override
+  void registrationStateChanged(RegistrationStateEnum state) {
+    this.setState(() {});
+  }
+
+  @override
+  void callStateChanged(CallState callState) {
+    if (callState.state == CallStateEnum.CALL_INITIATION) {
+      Navigator.pushNamed(context, '/callscreen');
+    }
   }
 }

--- a/example/lib/src/register.dart
+++ b/example/lib/src/register.dart
@@ -57,7 +57,7 @@ class _MyRegisterWidget extends State<RegisterWidget>
     prefs.commit();
   }
 
-  void registrationStateChanged(RegistrationStateEnum state) {
+  void registrationStateChanged(RegistrationStateEnum state, String cause) {
     this.setState(() {
       _registerState = state;
     });

--- a/example/lib/src/register.dart
+++ b/example/lib/src/register.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'sip_ua_helper.dart';
-import 'package:sip_ua/src/event_manager/event_manager.dart';
+import 'package:sip_ua/sip_ua.dart';
 
 class RegisterWidget extends StatefulWidget {
   final SIPUAHelper _helper;
@@ -10,7 +9,8 @@ class RegisterWidget extends StatefulWidget {
   _MyRegisterWidget createState() => _MyRegisterWidget();
 }
 
-class _MyRegisterWidget extends State<RegisterWidget> {
+class _MyRegisterWidget extends State<RegisterWidget>
+    implements SipUaHelperListener {
   String _password;
   String _wsUri;
   String _sipUri;
@@ -20,7 +20,7 @@ class _MyRegisterWidget extends State<RegisterWidget> {
     'Host': 'tryit.jssip.net:10443'
   };
   SharedPreferences prefs;
-  String _registerState;
+  RegistrationStateEnum _registerState;
 
   SIPUAHelper get helper => widget._helper;
 
@@ -28,16 +28,14 @@ class _MyRegisterWidget extends State<RegisterWidget> {
   initState() {
     super.initState();
     _registerState = helper.registerState;
-    helper.on(EventRegisterState(), _handleRegisterState);
-    helper.on(EventSocketState(), _handleSocketState);
+    helper.addSipUaHelperListener(this);
     _loadSettings();
   }
 
   @override
   deactivate() {
     super.deactivate();
-    helper.remove(EventRegisterState(), _handleRegisterState);
-    helper.remove(EventSocketState(), _handleSocketState);
+    helper.removeSipUaHelperListener(this);
     _saveSettings();
   }
 
@@ -59,15 +57,9 @@ class _MyRegisterWidget extends State<RegisterWidget> {
     prefs.commit();
   }
 
-  void _handleRegisterState(EventRegisterState data) {
+  void registrationStateChanged(RegistrationStateEnum state) {
     this.setState(() {
-      _registerState = data.state;
-    });
-  }
-
-  void _handleSocketState(EventSocketState data) {
-    this.setState(() {
-      _registerState = data.state;
+      _registerState = state;
     });
   }
 
@@ -122,7 +114,7 @@ class _MyRegisterWidget extends State<RegisterWidget> {
                             const EdgeInsets.fromLTRB(48.0, 18.0, 48.0, 18.0),
                         child: Center(
                             child: Text(
-                          'Register Status: $_registerState',
+                          'Register Status: ${EnumHelper.getName(_registerState)}',
                           style: TextStyle(fontSize: 18, color: Colors.black54),
                         )),
                       ),
@@ -257,5 +249,10 @@ class _MyRegisterWidget extends State<RegisterWidget> {
                         ),
                       ))
                 ])));
+  }
+
+  @override
+  void callStateChanged(CallState state) {
+    //NO OP
   }
 }

--- a/lib/sip_ua.dart
+++ b/lib/sip_ua.dart
@@ -1,4 +1,3 @@
-export 'src/Config.dart';
-export 'src/UA.dart';
-export 'src/WebSocketInterface.dart';
-export 'src/logger.dart';
+/// only expose the bare minimum of internals required
+export 'src/enum_helper.dart';
+export 'src/sip_ua_helper.dart';

--- a/lib/src/Config.dart
+++ b/lib/src/Config.dart
@@ -6,6 +6,7 @@ import 'Grammar.dart';
 import 'Socket.dart' as Socket;
 import 'URI.dart';
 import 'Utils.dart' as Utils;
+import 'WebSocketInterface.dart';
 import 'logger.dart';
 
 final logger = Log();

--- a/lib/src/Dialog.dart
+++ b/lib/src/Dialog.dart
@@ -4,6 +4,7 @@ import 'Dialog/RequestSender.dart';
 import 'Exceptions.dart' as Exceptions;
 import 'RTCSession.dart';
 import 'SIPMessage.dart' as SIPMessage;
+import 'UA.dart';
 import 'Utils.dart' as Utils;
 import 'event_manager/event_manager.dart';
 import 'logger.dart';

--- a/lib/src/Dialog/RequestSender.dart
+++ b/lib/src/Dialog/RequestSender.dart
@@ -5,6 +5,7 @@ import '../RTCSession.dart' as RTCSession;
 import '../RequestSender.dart';
 import '../SIPMessage.dart';
 import '../Timers.dart';
+import '../UA.dart';
 import '../event_manager/event_manager.dart';
 import '../transactions/transaction_base.dart';
 

--- a/lib/src/Message.dart
+++ b/lib/src/Message.dart
@@ -5,6 +5,7 @@ import 'Exceptions.dart' as Exceptions;
 import 'RequestSender.dart';
 import 'SIPMessage.dart' as SIPMessage;
 import 'SIPMessage.dart';
+import 'UA.dart';
 import 'Utils.dart' as Utils;
 import 'event_manager/event_manager.dart';
 import 'logger.dart';

--- a/lib/src/Parser.dart
+++ b/lib/src/Parser.dart
@@ -1,6 +1,7 @@
 import '../sip_ua.dart';
 import 'Grammar.dart';
 import 'SIPMessage.dart';
+import 'UA.dart';
 import 'logger.dart';
 
 final logger = new Log();

--- a/lib/src/RTCSession.dart
+++ b/lib/src/RTCSession.dart
@@ -19,6 +19,7 @@ import 'RequestSender.dart';
 import 'SIPMessage.dart';
 
 import 'Timers.dart';
+import 'UA.dart';
 import 'URI.dart';
 import 'Utils.dart' as Utils;
 import 'event_manager/event_manager.dart';

--- a/lib/src/Registrator.dart
+++ b/lib/src/Registrator.dart
@@ -6,6 +6,7 @@ import 'RequestSender.dart';
 import 'SIPMessage.dart';
 import 'Timers.dart';
 import 'Transport.dart';
+import 'UA.dart';
 import 'Utils.dart' as Utils;
 import 'event_manager/event_manager.dart';
 import 'logger.dart';

--- a/lib/src/RequestSender.dart
+++ b/lib/src/RequestSender.dart
@@ -3,6 +3,7 @@ import 'Constants.dart';
 import 'DigestAuthentication.dart';
 import 'SIPMessage.dart';
 import 'UA.dart' as UAC;
+import 'UA.dart';
 import 'event_manager/event_manager.dart';
 import 'logger.dart';
 import 'transactions/ack_client.dart';

--- a/lib/src/SIPMessage.dart
+++ b/lib/src/SIPMessage.dart
@@ -6,6 +6,7 @@ import 'Constants.dart' as DartSIP_C;
 import 'Exceptions.dart' as Exceptions;
 import 'Grammar.dart';
 import 'NameAddrHeader.dart';
+import 'UA.dart';
 import 'Utils.dart' as Utils;
 import 'logger.dart';
 

--- a/lib/src/UA.dart
+++ b/lib/src/UA.dart
@@ -14,6 +14,7 @@ import 'Timers.dart';
 import 'Transport.dart';
 import 'URI.dart';
 import 'Utils.dart' as Utils;
+import 'WebSocketInterface.dart';
 import 'event_manager/event_manager.dart';
 import 'logger.dart';
 import 'sanityCheck.dart';

--- a/lib/src/enum_helper.dart
+++ b/lib/src/enum_helper.dart
@@ -1,0 +1,33 @@
+import 'package:recase/recase.dart';
+
+///
+/// Provides a collection of methods that help when working with
+/// enums.
+///
+class EnumHelper {
+  static T getByIndex<T>(List<T> values, int index) {
+    return values.elementAt(index - 1);
+  }
+
+  static int getIndexOf<T>(List<T> values, T value) {
+    return values.indexOf(value);
+  }
+
+  ///
+  /// Returns the Enum name without the enum class.
+  /// e.g. DayName.Wednesday becomes Wednesday.
+  /// By default we recase the value to Title Case.
+  /// You can pass an alternate method to control the format.
+  ///
+  static String getName<T>(T enumValue,
+      {String Function(String value) recase = reCase}) {
+    String name = enumValue.toString();
+    int period = name.indexOf('.');
+
+    return recase(name.substring(period + 1));
+  }
+
+  static String reCase(String value) {
+    return ReCase(value).titleCase;
+  }
+}

--- a/lib/src/event_manager/event_manager.dart
+++ b/lib/src/event_manager/event_manager.dart
@@ -1,4 +1,5 @@
 import '../../sip_ua.dart';
+import '../logger.dart';
 import 'events.dart';
 
 export 'events.dart';

--- a/lib/src/event_manager/events.dart
+++ b/lib/src/event_manager/events.dart
@@ -7,6 +7,7 @@ import '../RTCSession/DTMF.dart';
 import '../RTCSession/Info.dart';
 import '../SIPMessage.dart';
 import '../Transport.dart';
+import '../WebSocketInterface.dart';
 import '../transactions/transaction_base.dart';
 
 /// each EventType class can implement this method and the EventManager will call it before
@@ -30,43 +31,6 @@ abstract class EventType {
 /// exactly what fields are available without the need to actually run the code.
 
 class EventStateChanged extends EventType {}
-
-class EventSocketState extends EventType {
-  String state;
-  IncomingMessage response;
-  EventSocketState({this.state, this.response});
-}
-
-class EventRegisterState extends EventType {
-  String state;
-  IncomingMessage response;
-  EventRegisterState({this.state, this.response});
-}
-
-class EventCallState extends EventType {
-  String state;
-  // dynamic response;
-  String originator;
-  MediaStream stream;
-  bool audio;
-  bool video;
-  EventCallState(
-      {this.state,
-      dynamic response,
-      this.originator,
-      this.stream,
-      this.audio,
-      this.video});
-}
-
-class EventUaState extends EventType {
-  String state;
-  // dynamic response;
-  // String originator;
-  // MediaStream stream;
-  EventUaState(
-      {this.state, dynamic response, String originator, MediaStream stream});
-}
 
 class EventNewTransaction extends EventType {
   // TransactionBase transaction;

--- a/lib/src/sanityCheck.dart
+++ b/lib/src/sanityCheck.dart
@@ -3,6 +3,7 @@ import 'Constants.dart' as DartSIP_C;
 import 'Constants.dart';
 import 'SIPMessage.dart';
 import 'Transport.dart';
+import 'UA.dart';
 import 'Utils.dart' as Utils;
 import 'logger.dart';
 import 'transactions/invite_server.dart';

--- a/lib/src/sip_ua_helper.dart
+++ b/lib/src/sip_ua_helper.dart
@@ -1,11 +1,14 @@
 import 'dart:async';
 import 'package:flutter_webrtc/media_stream.dart';
-import 'package:sip_ua/sip_ua.dart';
-import 'package:sip_ua/src/Message.dart';
-import 'package:sip_ua/src/RTCSession.dart';
-import 'package:sip_ua/src/SIPMessage.dart';
-import 'package:sip_ua/src/logger.dart';
-import 'package:sip_ua/src/event_manager/event_manager.dart';
+
+import 'Config.dart';
+import 'Message.dart';
+import 'RTCSession.dart';
+import 'UA.dart';
+import 'WebSocketInterface.dart';
+import 'logger.dart';
+import 'event_manager/event_manager.dart';
+import 'stack_trace_nj.dart';
 
 class SIPUAHelper extends EventManager {
   UA _ua;
@@ -14,15 +17,34 @@ class SIPUAHelper extends EventManager {
   RTCSession _session;
   bool _registered = false;
   bool _connected = false;
-  var _registerState = 'new';
-
-  RTCSession get session => _session;
+  RegistrationStateEnum _registerState = RegistrationStateEnum.NONE;
 
   bool get registered => _registered;
 
   bool get connected => _connected;
 
-  String get registerState => _registerState;
+  RegistrationStateEnum get registerState => _registerState;
+
+  String get remote_identity {
+    if (_session != null && _session.remote_identity != null) {
+      if (_session.remote_identity.display_name != null) {
+        return _session.remote_identity.display_name;
+      } else {
+        if (_session.remote_identity.uri != null &&
+            _session.remote_identity.uri.user != null) {
+          return _session.remote_identity.uri.user;
+        }
+      }
+    }
+    return "";
+  }
+
+  String get direction {
+    if (_session != null && _session.direction != null) {
+      return _session.direction.toUpperCase();
+    }
+    return "";
+  }
 
   void stop() async {
     await this._ua.stop();
@@ -41,7 +63,8 @@ class SIPUAHelper extends EventManager {
       _session = _ua.call(uri, this._options(voiceonly));
       return _session;
     } else {
-      logger.error("Not connected, you will need to register.");
+      logger.error(
+          "Not connected, you will need to register.", null, StackTraceNJ());
     }
     return null;
   }
@@ -63,7 +86,7 @@ class SIPUAHelper extends EventManager {
       String displayName,
       Map<String, dynamic> wsExtraHeaders]) async {
     if (this._ua != null) {
-      logger.error(
+      logger.warn(
           'UA instance already exist!, stopping UA and creating a new one...');
       this._ua.stop();
     }
@@ -78,40 +101,42 @@ class SIPUAHelper extends EventManager {
       this._ua = UA(_settings);
       this._ua.on(EventConnecting(), (EventConnecting event) {
         logger.debug('connecting => ' + event.toString());
-        _handleSocketState('connecting', null);
+        _notifyRegsistrationStateListeners(RegistrationStateEnum.CONNECTING);
       });
 
       this._ua.on(EventConnected(), (EventConnected event) {
         logger.debug('connected => ' + event.toString());
-        _handleSocketState('connected', null);
+        _notifyRegsistrationStateListeners(RegistrationStateEnum.CONNECTED);
         _connected = true;
       });
 
       this._ua.on(EventDisconnected(), (EventDisconnected event) {
         logger.debug('disconnected => ' + event.toString());
-        _handleSocketState('disconnected', null);
+        _notifyRegsistrationStateListeners(RegistrationStateEnum.DISCONNECTED);
         _connected = false;
       });
 
       this._ua.on(EventRegistered(), (EventRegistered event) {
         logger.debug('registered => ' + event.toString());
         _registered = true;
-        _registerState = 'registered';
-        _handleRegisterState('registered', event.response);
+        _registerState = RegistrationStateEnum.REGISTERED;
+        _notifyRegsistrationStateListeners(RegistrationStateEnum.REGISTERED);
       });
 
       this._ua.on(EventUnregister(), (EventUnregister event) {
         logger.debug('unregistered => ' + event.toString());
-        _registerState = 'unregistered';
+        _registerState = RegistrationStateEnum.UNREGISTERED;
         _registered = false;
-        _handleRegisterState('unregistered', event.response);
+        _notifyRegsistrationStateListeners(RegistrationStateEnum.UNREGISTERED);
       });
 
       this._ua.on(EventRegistrationFailed(), (EventRegistrationFailed event) {
         logger.debug('registrationFailed => ' + (event.cause));
-        _registerState = 'registrationFailed[${event.cause}]';
+        _registerState = RegistrationStateEnum
+            .REGISTRATION_FAILED; //'registrationFailed[${event.cause}]';
         _registered = false;
-        _handleRegisterState('registrationFailed', event.response);
+        _notifyRegsistrationStateListeners(
+            RegistrationStateEnum.REGISTRATION_FAILED);
       });
 
       this._ua.on(EventNewRTCSession(), (EventNewRTCSession event) {
@@ -122,18 +147,9 @@ class SIPUAHelper extends EventManager {
           _session
               .addAllEventHandlers(_options()['eventHandlers'] as EventManager);
         }
-        _handleUAState(EventUaState(state: "newRTCSession"));
+        _notifyCallStateListeners(CallState(CallStateEnum.CALL_INITIATION));
       });
 
-      this._ua.on(EventNewMessage(), (EventNewMessage event) {
-        logger.debug('newMessage => ' + event.toString());
-        _handleUAState(EventUaState(state: "newMessage"));
-      });
-
-      this._ua.on(EventSipEvent(), (EventSipEvent event) {
-        logger.debug('sipEvent => ' + event.toString());
-        _handleUAState(EventUaState(state: "sipEvent"));
-      });
       this._ua.start();
     } catch (e, s) {
       logger.error(e.toString(), null, s);
@@ -146,55 +162,61 @@ class SIPUAHelper extends EventManager {
 
     eventHandlers.on(EventConnecting(), (EventConnecting event) {
       logger.debug('call connecting');
-      _handleCallState('connecting', null, null, null, null, null);
+      _notifyCallStateListeners(CallState(CallStateEnum.CONNECTING));
     });
 
     eventHandlers.on(EventProgress(), (EventProgress event) {
       logger.debug('call is in progress');
-      _handleCallState(
-          'progress', event.response, null, event.originator, null, null);
+      _notifyCallStateListeners(
+          CallState(CallStateEnum.PROGRESS, originator: event.originator));
     });
 
     eventHandlers.on(EventFailed(), (EventFailed event) {
       logger.debug('call failed with cause: ' + (event.cause));
-      _handleCallState(
-          'failed', event.response, null, event.originator, null, null);
+      _notifyCallStateListeners(
+          CallState(CallStateEnum.FAILED, originator: event.originator));
       _session = null;
     });
 
     eventHandlers.on(EventEnded(), (EventEnded e) {
       logger.debug('call ended with cause: ' + (e.cause));
-      _handleCallState('ended', null, null, e.originator, null, null);
+      _notifyCallStateListeners(
+          CallState(CallStateEnum.ENDED, originator: e.originator));
       _session = null;
     });
     eventHandlers.on(EventCallAccepted(), (EventCallAccepted e) {
       logger.debug('call accepted');
-      _handleCallState('accepted', null, null, null, null, null);
+      _notifyCallStateListeners(CallState(CallStateEnum.ACCEPTED));
     });
     eventHandlers.on(EventConfirmed(), (EventConfirmed e) {
       logger.debug('call confirmed');
-      _handleCallState('confirmed', null, null, null, null, null);
+      _notifyCallStateListeners(CallState(CallStateEnum.CONFIRMED));
     });
     eventHandlers.on(EventHold(), (EventHold e) {
       logger.debug('call hold');
-      _handleCallState('hold', null, null, e.originator, null, null);
+      _notifyCallStateListeners(
+          CallState(CallStateEnum.HOLD, originator: e.originator));
     });
     eventHandlers.on(EventUnhold(), (EventUnhold e) {
       logger.debug('call unhold');
-      _handleCallState('unhold', null, null, e.originator, null, null);
+      _notifyCallStateListeners(
+          CallState(CallStateEnum.UNHOLD, originator: e.originator));
     });
     eventHandlers.on(EventMuted(), (EventMuted e) {
       logger.debug('call muted');
-      _handleCallState('muted', null, null, null, e.audio, e.video);
+      _notifyCallStateListeners(
+          CallState(CallStateEnum.MUTED, audio: e.audio, video: e.video));
     });
     eventHandlers.on(EventUnmuted(), (EventUnmuted e) {
       logger.debug('call unmuted');
-      _handleCallState('unmuted', null, null, null, e.audio, e.video);
+      _notifyCallStateListeners(
+          CallState(CallStateEnum.UNMUTED, audio: e.audio, video: e.video));
     });
     eventHandlers.on(EventStream(), (EventStream e) async {
       // Wating for callscreen ready.
       Timer(Duration(milliseconds: 100), () {
-        _handleCallState('stream', null, e.stream, e.originator, null, null);
+        _notifyCallStateListeners(
+            CallState(CallStateEnum.STREAM, stream: e.stream));
       });
     });
 
@@ -252,14 +274,6 @@ class SIPUAHelper extends EventManager {
     return _defaultOptions;
   }
 
-  void _handleSocketState(String state, IncomingMessage response) {
-    this.emit(EventSocketState(state: state, response: response));
-  }
-
-  void _handleRegisterState(String state, IncomingMessage response) {
-    this.emit(EventRegisterState(state: state, response: response));
-  }
-
   void hold() {
     if (_session != null) {
       _session.hold();
@@ -290,22 +304,6 @@ class SIPUAHelper extends EventManager {
     }
   }
 
-  void _handleCallState(String state, dynamic response, MediaStream stream,
-      String originator, bool audio, bool video) {
-    this.emit(EventCallState(
-        state: state,
-        response: response,
-        stream: stream,
-        originator: originator,
-        audio: audio,
-        video: video));
-  }
-
-  void _handleUAState(EventUaState event) {
-    logger.error("event $event");
-    this.emit(event);
-  }
-
   Message sendMessage(String target, String body,
       [Map<String, dynamic> options]) {
     return this._ua.sendMessage(target, body, options);
@@ -314,4 +312,67 @@ class SIPUAHelper extends EventManager {
   void terminateSessions(Map<String, dynamic> options) {
     this._ua.terminateSessions(options);
   }
+
+  Set<SipUaHelperListener> _sipUaHelperListeners = Set<SipUaHelperListener>();
+
+  void addSipUaHelperListener(SipUaHelperListener listener) {
+    _sipUaHelperListeners.add(listener);
+  }
+
+  void removeSipUaHelperListener(SipUaHelperListener listener) {
+    _sipUaHelperListeners.remove(listener);
+  }
+
+  void _notifyRegsistrationStateListeners(RegistrationStateEnum state) {
+    _sipUaHelperListeners.forEach((listener) {
+      listener.registrationStateChanged(state);
+    });
+  }
+
+  void _notifyCallStateListeners(CallState state) {
+    _sipUaHelperListeners.forEach((listener) {
+      listener.callStateChanged(state);
+    });
+  }
+}
+
+abstract class SipUaHelperListener {
+  void registrationStateChanged(RegistrationStateEnum state);
+  void callStateChanged(CallState state);
+}
+
+enum CallStateEnum {
+  STREAM,
+  UNMUTED,
+  MUTED,
+  CONNECTING,
+  PROGRESS,
+  FAILED,
+  ENDED,
+  ACCEPTED,
+  CONFIRMED,
+  HOLD,
+  UNHOLD,
+  NONE,
+  CALL_INITIATION
+}
+
+class CallState {
+  CallStateEnum state;
+  String originator;
+  bool audio;
+  bool video;
+  MediaStream stream;
+
+  CallState(this.state, {this.originator, this.audio, this.video, this.stream});
+}
+
+enum RegistrationStateEnum {
+  CONNECTING,
+  CONNECTED,
+  DISCONNECTED,
+  REGISTRATION_FAILED,
+  REGISTERED,
+  UNREGISTERED,
+  NONE,
 }

--- a/lib/src/transactions/ack_client.dart
+++ b/lib/src/transactions/ack_client.dart
@@ -1,7 +1,9 @@
 import '../../sip_ua.dart';
 import '../Transport.dart';
+import '../UA.dart';
 import '../Utils.dart';
 import '../event_manager/event_manager.dart';
+import '../logger.dart';
 import 'transaction_base.dart';
 
 final act_logger = new Log();

--- a/lib/src/transactions/invite_client.dart
+++ b/lib/src/transactions/invite_client.dart
@@ -3,8 +3,10 @@ import '../Constants.dart';
 import '../SIPMessage.dart' as SIPMessage;
 import '../Timers.dart';
 import '../Transport.dart';
+import '../UA.dart';
 import '../Utils.dart';
 import '../event_manager/event_manager.dart';
+import '../logger.dart';
 import 'transaction_base.dart';
 
 final logger = new Log();

--- a/lib/src/transactions/invite_server.dart
+++ b/lib/src/transactions/invite_server.dart
@@ -1,7 +1,9 @@
 import '../../sip_ua.dart';
 import '../Timers.dart';
 import '../Transport.dart';
+import '../UA.dart';
 import '../event_manager/event_manager.dart';
+import '../logger.dart';
 import 'transaction_base.dart';
 
 final logger = new Log();

--- a/lib/src/transactions/non_invite_client.dart
+++ b/lib/src/transactions/non_invite_client.dart
@@ -2,8 +2,10 @@ import '../../sip_ua.dart';
 import '../SIPMessage.dart';
 import '../Timers.dart';
 import '../Transport.dart';
+import '../UA.dart';
 import '../Utils.dart';
 import '../event_manager/event_manager.dart';
+import '../logger.dart';
 import 'transaction_base.dart';
 
 final logger = new Log();

--- a/lib/src/transactions/non_invite_server.dart
+++ b/lib/src/transactions/non_invite_server.dart
@@ -1,7 +1,9 @@
 import '../../sip_ua.dart';
 import '../Timers.dart';
 import '../Transport.dart';
+import '../UA.dart';
 import '../event_manager/event_manager.dart';
+import '../logger.dart';
 import 'transaction_base.dart';
 
 final logger = new Log();

--- a/lib/src/transactions/transaction_base.dart
+++ b/lib/src/transactions/transaction_base.dart
@@ -1,5 +1,6 @@
 import '../../sip_ua.dart';
 import '../Transport.dart';
+import '../UA.dart';
 import '../event_manager/event_manager.dart';
 
 enum TransactionState {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   random_string: ^1.1.0
   logger: ^0.7.0+2
   intl: ^0.16.0
+  recase: ^2.0.1
   
 dev_dependencies:
   test: ^1.6.7

--- a/test/test_sip_ua.dart
+++ b/test/test_sip_ua.dart
@@ -1,3 +1,4 @@
+import 'package:sip_ua/src/UA.dart';
 import 'package:test/test.dart';
 import 'package:sip_ua/sip_ua.dart';
 import 'package:sip_ua/src/Config.dart' as config;


### PR DESCRIPTION
I've divided this PR into 2 commits. Although neither commit is viable without the other, it helps to separate the simple and complex parts of this PR.

The first commit https://github.com/cloudwebrtc/dart-sip-ua/commit/acdba147f83f6f5a610d90af4630f2b79a879e9f simply changes paths and imports

The second commit https://github.com/cloudwebrtc/dart-sip-ua/commit/e0c474cf9f88f4cfa2e822ac62d151ae39374a81 is concerned with changing the listener mechanism between example and sip_ua_helper

