### PR TITLE
Types and logs pr

### DIFF
--- a/lib/src/Config.dart
+++ b/lib/src/Config.dart
@@ -249,7 +249,7 @@ load(dst, src) {
 
     // Check Optional parameters.
     checks.optional.forEach((parameter, fun) {
-      logger.info('Check optional parameter => ${parameter}.');
+      logger.debug('Check optional parameter => ${parameter}.');
       fun(src, dst);
     });
   } catch (e) {

--- a/lib/src/Dialog.dart
+++ b/lib/src/Dialog.dart
@@ -4,6 +4,7 @@ import 'Dialog/RequestSender.dart';
 import 'Exceptions.dart' as Exceptions;
 import 'RTCSession.dart';
 import 'SIPMessage.dart' as SIPMessage;
+import 'SIPMessage.dart';
 import 'UA.dart';
 import 'Utils.dart' as Utils;
 import 'event_manager/event_manager.dart';
@@ -165,7 +166,7 @@ class Dialog {
     return request;
   }
 
-  receiveRequest(request) {
+  receiveRequest(IncomingRequest request) {
     // Check in-dialog request.
     if (!this._checkInDialogRequest(request)) {
       return;

--- a/lib/src/Parser.dart
+++ b/lib/src/Parser.dart
@@ -135,7 +135,7 @@ getHeader(String data, int headerStart) {
   return end;
 }
 
-parseHeader(message, data, headerStart, headerEnd) {
+parseHeader(IncomingMessage message, data, headerStart, headerEnd) {
   var parsed;
   var hcolonIndex = data.indexOf(':', headerStart);
   var headerName = data.substring(headerStart, hcolonIndex).trim();

--- a/lib/src/RTCSession.dart
+++ b/lib/src/RTCSession.dart
@@ -1760,7 +1760,7 @@ class RTCSession extends EventManager {
   /**
    * In dialog UPDATE Reception
    */
-  void _receiveUpdate(request) async {
+  void _receiveUpdate(IncomingRequest request) async {
     logger.debug('receiveUpdate()');
 
     var rejected = false;

--- a/lib/src/SIPMessage.dart
+++ b/lib/src/SIPMessage.dart
@@ -8,7 +8,9 @@ import 'Grammar.dart';
 import 'NameAddrHeader.dart';
 import 'UA.dart';
 import 'Utils.dart' as Utils;
+import 'grammar_parser.dart';
 import 'logger.dart';
+import 'transactions/transaction_base.dart';
 
 final logger = Log();
 
@@ -343,9 +345,12 @@ class IncomingMessage {
   var reason_phrase;
   var session_expires;
   var session_expires_refresher;
+  Data event;
+  dynamic replaces;
+  dynamic refer_to;
 
   IncomingMessage() {
-    this.data = null;
+    this.data = '';
     this.headers = null;
     this.method = null;
     this.via = null;
@@ -356,7 +361,7 @@ class IncomingMessage {
     this.from_tag = null;
     this.to = null;
     this.to_tag = null;
-    this.body = null;
+    this.body = '';
     this.sdp = null;
   }
 
@@ -505,7 +510,7 @@ class IncomingRequest extends IncomingMessage {
   UA ua;
   var ruri;
   var transport;
-  var server_transaction;
+  TransactionBase server_transaction;
 
   IncomingRequest(UA ua) : super() {
     this.ua = ua;
@@ -623,9 +628,12 @@ class IncomingRequest extends IncomingMessage {
       response += 'Content-Length: ${0}\r\n\r\n';
     }
 
+    IncomingMessage message = IncomingMessage();
+    message.data = response;
+
     this
         .server_transaction
-        .receiveResponse(code, response, onSuccess, onFailure);
+        .receiveResponse(code, message, onSuccess, onFailure);
   }
 
   /**

--- a/lib/src/WebSocketInterface.dart
+++ b/lib/src/WebSocketInterface.dart
@@ -133,8 +133,10 @@ class WebSocketInterface implements Socket {
       });
       _closed = false;
       _connected = true;
+      logger.debug("Web Socket is now connected");
       this._onOpen();
-    } catch (e) {
+    } catch (e, s) {
+      Log.e(e.toString(), null, s);
       _connected = false;
       this._onError(e.toString());
     }

--- a/lib/src/event_manager/events.dart
+++ b/lib/src/event_manager/events.dart
@@ -69,7 +69,7 @@ class EventUnregister extends EventType {
 
 class EventSipEvent extends EventType {
   //OutgoingRequest request;
-  EventSipEvent({OutgoingRequest request});
+  EventSipEvent({IncomingRequest request});
 }
 
 class EventConnected extends EventType {

--- a/lib/src/event_manager/events.dart
+++ b/lib/src/event_manager/events.dart
@@ -175,7 +175,7 @@ class EventUpdate extends EventType {
 //  bool Function(dynamic options) callback;
 //  bool Function(dynamic options) reject;
   EventUpdate(
-      {dynamic request,
+      {IncomingRequest request,
       bool Function(dynamic options) callback,
       bool Function(dynamic options) reject});
 }

--- a/lib/src/logger.dart
+++ b/lib/src/logger.dart
@@ -1,39 +1,40 @@
 import 'package:intl/intl.dart';
 import 'package:logger/logger.dart';
 
+import 'enum_helper.dart';
 import 'stack_trace_nj.dart';
 
 class Log extends Logger {
   static Log _self;
   static String _localPath;
 
+  static Level _loggingLevel = Level.debug;
+
   Log();
+
+  static set loggingLevel(Level loggingLevel) => _loggingLevel = loggingLevel;
 
   Log._internal(String currentWorkingDirectory)
       : super(printer: MyLogPrinter(currentWorkingDirectory));
 
-  debug(String message, [dynamic error, StackTrace stackTrace]) {
+  void debug(String message, [dynamic error, StackTrace stackTrace]) {
     autoInit();
     Log.d(message, error, stackTrace);
-    return _self;
   }
 
-  info(String message, [dynamic error, StackTrace stackTrace]) {
+  void info(String message, [dynamic error, StackTrace stackTrace]) {
     autoInit();
     Log.i(message, error, stackTrace);
-    return _self;
   }
 
-  warn(String message, [dynamic error, StackTrace stackTrace]) {
+  void warn(String message, [dynamic error, StackTrace stackTrace]) {
     autoInit();
     Log.w(message, error, stackTrace);
-    return _self;
   }
 
-  error(String message, [dynamic error, StackTrace stackTrace]) {
+  void error(String message, [dynamic error, StackTrace stackTrace]) {
     autoInit();
     Log.e(message, error, stackTrace);
-    return _self;
   }
 
   factory Log.d(String message, [dynamic error, StackTrace stackTrace]) {
@@ -80,7 +81,7 @@ class Log extends Logger {
 }
 
 class MyLogPrinter extends LogPrinter {
-  static final levelColors = {
+  static final Map<Level, AnsiColor> levelColors = {
     Level.verbose: AnsiColor.fg(AnsiColor.grey(0.5)),
     Level.debug: AnsiColor.none(),
     Level.info: AnsiColor.fg(12),
@@ -96,6 +97,11 @@ class MyLogPrinter extends LogPrinter {
 
   @override
   void log(LogEvent event) {
+    if (EnumHelper.getIndexOf(Level.values, Log._loggingLevel) >
+        EnumHelper.getIndexOf(Level.values, event.level)) {
+      // don't log events where the log level is set higher
+      return;
+    }
     var formatter = DateFormat('yyyy-MM-dd HH:mm:ss.');
     var now = DateTime.now();
     var formattedDate = formatter.format(now) + now.millisecond.toString();

--- a/lib/src/sip_ua_helper.dart
+++ b/lib/src/sip_ua_helper.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:flutter_webrtc/media_stream.dart';
+import 'package:logger/logger.dart';
 
 import 'Config.dart';
 import 'Message.dart';
@@ -24,6 +25,12 @@ class SIPUAHelper extends EventManager {
   bool get connected => _connected;
 
   RegistrationStateEnum get registerState => _registerState;
+
+  SIPUAHelper() {
+    Log.loggingLevel = Level.debug;
+  }
+
+  set loggingLevel(Level loggingLevel) => Log.loggingLevel = loggingLevel;
 
   String get remote_identity {
     if (_session != null && _session.remote_identity != null) {

--- a/lib/src/sip_ua_helper.dart
+++ b/lib/src/sip_ua_helper.dart
@@ -47,15 +47,33 @@ class SIPUAHelper extends EventManager {
   }
 
   void stop() async {
-    await this._ua.stop();
+    if (this._ua != null) {
+      await this._ua.stop();
+    } else {
+      Log.w("ERROR: stop called but not started, call start first.");
+    }
   }
 
   void register() {
+    assert(this._ua != null,
+        "register called but not started, you must call start first.");
     this._ua.register();
   }
 
+  bool isRegistered() {
+    if (this._ua != null) {
+      return this._ua.isRegistered();
+    }
+    return false;
+  }
+
   void unregister([bool all = true]) {
-    this._ua.unregister(all: all);
+    if (this._ua != null) {
+      assert(!this._ua.isRegistered(), "ERROR: you must call register first.");
+      this._ua.unregister(all: all);
+    } else {
+      Log.e("ERROR: unregister called, you must call start first.");
+    }
   }
 
   Future<RTCSession> call(String uri, [bool voiceonly = false]) async {
@@ -135,7 +153,7 @@ class SIPUAHelper extends EventManager {
       });
 
       this._ua.on(EventRegistrationFailed(), (EventRegistrationFailed event) {
-        logger.debug('registrationFailed => ' + (event.cause));
+        logger.error('registrationFailed => ' + (event.cause));
         _registerState = RegistrationStateEnum
             .REGISTRATION_FAILED; //'registrationFailed[${event.cause}]';
         _registered = false;

--- a/lib/src/transactions/invite_client.dart
+++ b/lib/src/transactions/invite_client.dart
@@ -1,6 +1,7 @@
 import '../../sip_ua.dart';
 import '../Constants.dart';
 import '../SIPMessage.dart' as SIPMessage;
+import '../SIPMessage.dart';
 import '../Timers.dart';
 import '../Transport.dart';
 import '../UA.dart';
@@ -134,7 +135,8 @@ class InviteClientTransaction extends TransactionBase {
     this.transport.send(cancel);
   }
 
-  receiveResponse(SIPMessage.IncomingMessage response) {
+  void receiveResponse(int status_code, IncomingMessage response,
+      [void Function() onSuccess, void Function() onFailure]) {
     var status_code = response.status_code;
 
     if (status_code >= 100 && status_code <= 199) {

--- a/lib/src/transactions/invite_server.dart
+++ b/lib/src/transactions/invite_server.dart
@@ -1,4 +1,5 @@
 import '../../sip_ua.dart';
+import '../SIPMessage.dart';
 import '../Timers.dart';
 import '../Transport.dart';
 import '../UA.dart';
@@ -18,7 +19,7 @@ class InviteServerTransaction extends TransactionBase {
     this.ua = ua;
     this.transport = transport;
     this.request = request;
-    this.last_response = '';
+    this.last_response = IncomingMessage();
     request.server_transaction = this;
 
     this.state = TransactionState.PROCEEDING;
@@ -87,7 +88,8 @@ class InviteServerTransaction extends TransactionBase {
   }
 
   // INVITE Server Transaction RFC 3261 17.2.1.
-  receiveResponse(status_code, response, onSuccess, onFailure) {
+  void receiveResponse(int status_code, IncomingMessage response,
+      [void Function() onSuccess, void Function() onFailure]) {
     if (status_code >= 100 && status_code <= 199) {
       switch (this.state) {
         case TransactionState.PROCEEDING:

--- a/lib/src/transactions/non_invite_client.dart
+++ b/lib/src/transactions/non_invite_client.dart
@@ -68,9 +68,8 @@ class NonInviteClientTransaction extends TransactionBase {
     this.ua.destroyTransaction(this);
   }
 
-  receiveResponse(IncomingResponse response) {
-    var status_code = response.status_code;
-
+  void receiveResponse(int status_code, IncomingMessage response,
+      [void Function() onSuccess, void Function() onFailure]) {
     if (status_code < 200) {
       switch (this.state) {
         case TransactionState.TRYING:

--- a/lib/src/transactions/non_invite_server.dart
+++ b/lib/src/transactions/non_invite_server.dart
@@ -1,3 +1,5 @@
+import 'package:sip_ua/src/SIPMessage.dart';
+
 import '../../sip_ua.dart';
 import '../Timers.dart';
 import '../Transport.dart';
@@ -17,7 +19,7 @@ class NonInviteServerTransaction extends TransactionBase {
     this.ua = ua;
     this.transport = transport;
     this.request = request;
-    this.last_response = '';
+    this.last_response = IncomingMessage();
     request.server_transaction = this;
 
     this.state = TransactionState.TRYING;
@@ -48,7 +50,8 @@ class NonInviteServerTransaction extends TransactionBase {
     }
   }
 
-  receiveResponse(status_code, response, onSuccess, onFailure) {
+  receiveResponse(int status_code, IncomingMessage response,
+      [void Function() onSuccess, void Function() onFailure]) {
     if (status_code == 100) {
       /* RFC 4320 4.1
        * 'A SIP element MUST NOT

--- a/lib/src/transactions/transaction_base.dart
+++ b/lib/src/transactions/transaction_base.dart
@@ -1,4 +1,5 @@
 import '../../sip_ua.dart';
+import '../SIPMessage.dart';
 import '../Transport.dart';
 import '../UA.dart';
 import '../event_manager/event_manager.dart';
@@ -19,9 +20,14 @@ abstract class TransactionBase extends EventManager {
   UA ua;
   Transport transport;
   TransactionState state;
-  var last_response;
+  IncomingMessage last_response;
   var request;
   void onTransportError();
 
   void send();
+
+  void receiveResponse(int status_code, IncomingMessage response,
+      [void Function() onSuccess, void Function() onFailure]) {
+    // default NO_OP implementation
+  }
 }


### PR DESCRIPTION
Add control over the logging level, default is still debug. 
SIPUPHelper now has a setter for loggingLevel
If a logger call is below the set Level, then the log output will be suppressed.

Improved error messages when attempting to connect and register.

Inferred more type information.

adjusted some logging levels from debug to info