### PR TITLE
fix for dart:html import and related errors

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:flutter/foundation.dart'
     show debugDefaultTargetPlatformOverride;
 
@@ -11,8 +10,9 @@ import 'src/callscreen.dart';
 import 'src/about.dart';
 
 void main() {
-  if (WebRTC.platformIsDesktop)
+  if (WebRTC.platformIsDesktop) {
     debugDefaultTargetPlatformOverride = TargetPlatform.fuchsia;
+  }
   runApp(MyApp());
 }
 

--- a/example/lib/src/callscreen.dart
+++ b/example/lib/src/callscreen.dart
@@ -159,7 +159,7 @@ class _MyCallScreenWidget extends State<CallScreenWidget>
   }
 
   void _handelStreams(CallState event) async {
-    var stream = event.stream;
+    MediaStream stream = event.stream;
     if (event.originator == 'local') {
       if (_localRenderer != null) {
         _localRenderer.srcObject = stream;
@@ -238,16 +238,16 @@ class _MyCallScreenWidget extends State<CallScreenWidget>
         return AlertDialog(
           title: Text('Enter target to transfer.'),
           content: TextField(
-              onChanged: (String text) {
-                setState(() {
-                  _tansfer_target = text;
-                });
-              },
-              decoration: InputDecoration(
-                hintText: 'URI or Username',
-              ),
-              textAlign: TextAlign.center,
+            onChanged: (String text) {
+              setState(() {
+                _tansfer_target = text;
+              });
+            },
+            decoration: InputDecoration(
+              hintText: 'URI or Username',
             ),
+            textAlign: TextAlign.center,
+          ),
           actions: <Widget>[
             FlatButton(
               child: Text('Ok'),

--- a/example/lib/src/utils/dart_html_dummy.dart
+++ b/example/lib/src/utils/dart_html_dummy.dart
@@ -1,0 +1,12 @@
+/*
+ * Theses classes simply serve to remove compile errors
+ * when building for a flutter environment 
+ */
+class Storage {
+  Map<String, String> store = Map();
+
+  String operator [](String key) => store[key];
+  operator []=(String key, String value) => store[key] = value;
+}
+
+dynamic window;

--- a/example/lib/src/utils/key_value_store.dart
+++ b/example/lib/src/utils/key_value_store.dart
@@ -5,7 +5,7 @@ class KeyValueStore {
   KeyValueStore();
   SharedPreferences _preferences;
 
-  init() async {
+  void init() async {
     _preferences = await SharedPreferences.getInstance();
   }
 

--- a/example/lib/src/utils/key_value_store_web.dart
+++ b/example/lib/src/utils/key_value_store_web.dart
@@ -1,13 +1,13 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:html';
+import 'dart_html_dummy.dart' if (dart.library.js) 'dart:html';
 
 class KeyValueStore {
   KeyValueStore();
   Storage _storage;
 
-  init() async {
-    _storage = window.localStorage;
+  void init() async {
+    _storage = window.localStorage as Storage;
   }
 
   String getString(String key) => _storage[key];

--- a/lib/src/dialog.dart
+++ b/lib/src/dialog.dart
@@ -236,7 +236,7 @@ class Dialog {
     } else if (request.cseq > this._remote_seqnum) {
       this._remote_seqnum = request.cseq;
     }
-    EventManager eventHandlers = request.server_transaction as EventManager;
+    EventManager eventHandlers = request.server_transaction;
     // RFC3261 14.2 Modifying an Existing Session -UAS BEHAVIOR-.
     if (request.method == SipMethod.INVITE ||
         (request.method == SipMethod.UPDATE && request.body != null)) {

--- a/lib/src/logger.dart
+++ b/lib/src/logger.dart
@@ -114,7 +114,7 @@ class MyLogPrinter extends LogPrinter {
     for (Stackframe frame in frames.frames) {
       i++;
       var path2 = frame.sourceFile.path;
-      if (!path2.contains(Log._localPath)) {
+      if (!path2.contains(Log._localPath) && !path2.contains("logger.dart")) {
         depth = i - 1;
         break;
       }

--- a/lib/src/web_socket_dummy.dart
+++ b/lib/src/web_socket_dummy.dart
@@ -1,0 +1,29 @@
+/*
+ * Theses classes simply serve to remove compile errors
+ * when building for a flutter environment 
+ */
+
+class WebSocket {
+  static var OPEN;
+  static var CONNECTING;
+
+  WebSocket(String url, String s);
+
+  get onOpen => null;
+
+  get onMessage => null;
+
+  get onClose => null;
+
+  get readyState => null;
+
+  void send(data) {}
+
+  void close() {}
+}
+
+class Blob {}
+
+dynamic callMethod(var a, var b, var c) {}
+
+Future<dynamic> promiseToFuture(var promise) {}

--- a/lib/src/websocket_interface.dart
+++ b/lib/src/websocket_interface.dart
@@ -120,7 +120,8 @@ class WebSocketInterface implements Socket {
         this._ws.close();
       }
     } catch (error) {
-      logger.error('close() | error closing the WebSocket: ' + error);
+      logger
+          .error('close() | error closing the WebSocket: ' + error.toString());
     }
   }
 

--- a/lib/src/websocket_web_impl.dart
+++ b/lib/src/websocket_web_impl.dart
@@ -1,5 +1,5 @@
-import 'dart:html';
-import 'dart:js_util' as JSUtils;
+import 'web_socket_dummy.dart' if (dart.library.js) 'dart:html';
+import 'web_socket_dummy.dart' if (dart.library.js) 'dart:js_util' as JSUtils;
 import 'logger.dart';
 
 typedef void OnMessageCallback(dynamic msg);


### PR DESCRIPTION
Merry Christmas and a Happy new year, I've been busy with another project for a while.

The dart:html (and others) import were causing compile errors for the flutter environment.

I've added conditional imports and alternative non-functional dummy classes to enable a clean compile.

There are also a few minor formatting and syntax changes to address some compile warnings and errors.

and finally a small fix for the logger.