### PR TITLE
Prevent sharing of config between different UA instances

### DIFF
--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -58,8 +58,6 @@ class Settings {
   var hostport_params = null;
 }
 
-var settings = new Settings();
-
 // Configuration checks.
 class Checks {
   var mandatory = {

--- a/lib/src/ua.dart
+++ b/lib/src/ua.dart
@@ -104,7 +104,7 @@ class UA extends EventManager {
 
     this._cache = {'credentials': {}};
 
-    this._configuration = config.settings;
+    this._configuration = new Settings();
     this._dynConfiguration = new DynamicSettings();
     this._dialogs = {};
 


### PR DESCRIPTION
The global instance of `Settings` in `lib/src/config.dart` causes different UA instances to share settings, meaning that e.g. all instances try to auth with the same credentials even if initialised with different creds. This solves that by creating a new `Settings` instance for each UA.