### PR TITLE
Add SIP message listener to listen the new incoming SIP text message

### DIFF
--- a/example/lib/src/callscreen.dart
+++ b/example/lib/src/callscreen.dart
@@ -541,4 +541,9 @@ class _MyCallScreenWidget extends State<CallScreenWidget>
             padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 24.0),
             child: Container(width: 320, child: _buildActionButtons())));
   }
+
+  @override
+  void onNewMessage(SIPMessageRequest msg) {
+    // NO OP
+  }
 }

--- a/example/lib/src/dialpad.dart
+++ b/example/lib/src/dialpad.dart
@@ -18,9 +18,12 @@ class _MyDialPadWidget extends State<DialPadWidget>
   TextEditingController _textController;
   SharedPreferences _preferences;
 
+  String receivedMsg;
+
   @override
   initState() {
     super.initState();
+    receivedMsg = "";
     _bindEventListeners();
     _loadSettings();
   }
@@ -31,6 +34,7 @@ class _MyDialPadWidget extends State<DialPadWidget>
         _preferences.getString('dest') ?? 'sip:hello_jssip@tryit.jssip.net';
     _textController = TextEditingController(text: _dest);
     _textController.text = _dest;
+    
     this.setState(() {});
   }
 
@@ -248,6 +252,14 @@ class _MyDialPadWidget extends State<DialPadWidget>
                       style: TextStyle(fontSize: 14, color: Colors.black54),
                     )),
                   ),
+                  Padding(
+                    padding: const EdgeInsets.all(6.0),
+                    child: Center(
+                        child: Text(
+                      'Received Message: ${receivedMsg}',
+                      style: TextStyle(fontSize: 14, color: Colors.black54),
+                    )),
+                  ),
                   Container(
                       child: Column(
                     crossAxisAlignment: CrossAxisAlignment.center,
@@ -270,5 +282,14 @@ class _MyDialPadWidget extends State<DialPadWidget>
     if (callState.state == CallStateEnum.CALL_INITIATION) {
       Navigator.pushNamed(context, '/callscreen');
     }
+  }
+
+  @override
+  void onNewMessage(SIPMessageRequest msg) {
+     //Save the incoming message to DB
+    String msgBody = msg.request.body as String;
+    setState(() {
+      receivedMsg = msgBody;
+    });
   }
 }

--- a/example/lib/src/register.dart
+++ b/example/lib/src/register.dart
@@ -301,4 +301,9 @@ class _MyRegisterWidget extends State<RegisterWidget>
 
   @override
   void transportStateChanged(TransportState state) {}
+
+  @override
+  void onNewMessage(SIPMessageRequest msg) {
+    // NO OP
+  }
 }

--- a/lib/src/event_manager/event_manager.dart
+++ b/lib/src/event_manager/event_manager.dart
@@ -3,12 +3,14 @@ import 'call_events.dart';
 import 'refer_events.dart';
 import 'register_events.dart';
 import 'transport_events.dart';
+import 'message_events.dart';
 
 export 'events.dart';
 export 'call_events.dart';
 export 'refer_events.dart';
 export 'register_events.dart';
 export 'transport_events.dart';
+export 'message_events.dart';
 
 import '../logger.dart';
 

--- a/lib/src/event_manager/internal_events.dart
+++ b/lib/src/event_manager/internal_events.dart
@@ -24,13 +24,6 @@ class EventTransactionDestroyed extends EventType {
   EventTransactionDestroyed({this.transaction});
 }
 
-class EventNewMessage extends EventType {
-  dynamic request;
-  String originator;
-  Message message;
-  EventNewMessage({this.message, this.originator, this.request});
-}
-
 class EventSipEvent extends EventType {
   IncomingRequest request;
   EventSipEvent({this.request});

--- a/lib/src/event_manager/message_events.dart
+++ b/lib/src/event_manager/message_events.dart
@@ -1,0 +1,9 @@
+import '../message.dart';
+import 'events.dart';
+
+class EventNewMessage extends EventType {
+  dynamic request;
+  String originator;
+  Message message;
+  EventNewMessage({this.message, this.originator, this.request});
+}

--- a/lib/src/message.dart
+++ b/lib/src/message.dart
@@ -55,8 +55,8 @@ class Message extends EventManager {
     }
 
     // Check target validity.
-    target = this._ua.normalizeTarget(target);
-    if (target == null) {
+    var normalized = this._ua.normalizeTarget(target);
+    if (normalized == null) {
       throw new Exceptions.TypeError('Invalid target: ${originalTarget}');
     }
 
@@ -71,7 +71,7 @@ class Message extends EventManager {
     extraHeaders.add('Content-Type: $contentType');
 
     this._request = new SIPMessage.OutgoingRequest(
-        SipMethod.MESSAGE, target, this._ua, null, extraHeaders);
+      SipMethod.MESSAGE, normalized, this._ua, null, extraHeaders);
     if (body != null) {
       this._request.body = body;
     }

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -1,3 +1,4 @@
+import 'dart:convert' show utf8;
 import '../sip_ua.dart';
 import 'grammar.dart';
 import 'sip_message.dart';
@@ -86,7 +87,11 @@ IncomingMessage parseMessage(String data, UA ua) {
     if (contentLength is String) {
       contentLength = int.tryParse(contentLength) ?? 0;
     }
-    message.body = data.substring(bodyStart, bodyStart + contentLength);
+        if(contentLength > 0) {
+      var encoded = utf8.encode(data);
+      List<int> content = encoded.sublist(bodyStart, bodyStart + contentLength);
+      message.body = utf8.decode(content);
+    }
   } else {
     message.body = data.substring(bodyStart);
   }

--- a/lib/src/sip_message.dart
+++ b/lib/src/sip_message.dart
@@ -1,3 +1,4 @@
+import 'dart:convert' show utf8;
 import 'package:sdp_transform/sdp_transform.dart' as sdp_transform;
 
 import '../sip_ua.dart';
@@ -269,7 +270,10 @@ class OutgoingRequest {
     msg += 'User-Agent: ${userAgent}\r\n';
 
     if (this.body != null) {
-      var length = this.body.length;
+      logger.debug("Outgoing Message: " + this.body);
+      //Here we should calculate the real content length for UTF8
+      var encoded = utf8.encode(this.body);
+      var length = encoded.length;
       msg += 'Content-Length: ${length}\r\n\r\n';
       msg += this.body;
     } else {

--- a/lib/src/ua.dart
+++ b/lib/src/ua.dart
@@ -557,6 +557,7 @@ class UA extends EventManager {
       }
       var message = new Message(this);
       message.init_incoming(request);
+      return;
     } else if (method == SipMethod.INVITE) {
       // Initial INVITE.
       if (request.to_tag != null && !this.hasListeners(EventNewRTCSession())) {


### PR DESCRIPTION
Add support listening to incoming SIP text message

- Move EventNewMessage from internal event as export event type to be used.
- Add a new override function void onNewMessage(SIPMessageRequest msg) to interface. User should process the new incoming text message in this function.
- Fix the problem that content length of SIP message was not calculated correctly when UTF-8 characters were met.
- Modify the example to show the incoming text message on dial pad screen.

In the new example, send text message to registed client of the SIP UA, the message will be shown on dial pad screen. And the code handling incoming message looks like below in dialpad.dart.

void onNewMessage(SIPMessageRequest msg) {
     //Save the incoming message to DB
    String msgBody = msg.request.body as String;
    setState(() {
      receivedMsg = msgBody;
    });
  }
