### PR TITLE
Expose existing functionality via UaSettings() for RFC8599 usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A dart-lang version of the SIP UA stack, ported from [JsSIP](https://github.com/
 - SIP over WebSocket (use real SIP in your flutter mobile, [desktop](https://flutter.dev/desktop), [web](https://flutter.dev/web) apps)
 - Audio/video calls ([flutter-webrtc](https://github.com/cloudwebrtc/flutter-webrtc)) and instant messaging
 - Support with standard SIP servers such as OpenSIPS, Kamailio, Asterisk and FreeSWITCH.
+- RFC8599 Push Notification Support using Contact Params - https://tools.ietf.org/html/rfc8599#section-4
 
 ## Currently supported platforms
 - [X] iOS

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -39,6 +39,8 @@ class Settings {
   // Registration parameters.
   var register = true;
   var register_expires = 600;
+  var register_extra_headers = null;
+  var register_extra_contact_params = null;
   var registrar_server = null;
 
   // Connection options.
@@ -209,6 +211,20 @@ class Checks {
       if (register_expires == null) return;
       if (register_expires > 0) {
         dst.register_expires = register_expires;
+      }
+    },
+    'register_extra_headers': (src, dst) {
+      var register_extra_headers = src.register_extra_headers;
+      if (register_extra_headers == null) return;
+      if (register_extra_headers is List<String>) {
+        dst.register_extra_headers = register_extra_headers;
+      }
+    },
+    'register_extra_contact_params': (src, dst) {
+      var register_extra_contact_params = src.register_extra_contact_params;
+      if (register_extra_contact_params == null) return;
+      if (register_extra_contact_params is Map<String, dynamic>) {
+        dst.register_extra_contact_params = register_extra_contact_params;
       }
     },
     'registrar_server': (src, dst) {

--- a/lib/src/registrator.dart
+++ b/lib/src/registrator.dart
@@ -66,10 +66,10 @@ class Registrator {
     this._contact += ';+sip.ice';
 
     // Custom headers for REGISTER and un-REGISTER.
-    this._extraHeaders = [];
+    this.setExtraHeaders(ua.configuration.register_extra_headers);
 
     // Custom Contact header params for REGISTER and un-REGISTER.
-    this._extraContactParams = '';
+    this.setExtraContactParams(ua.configuration.register_extra_contact_params);
 
     if (reg_id != null) {
       this._contact += ';reg-id=${reg_id}';
@@ -111,7 +111,7 @@ class Registrator {
       return;
     }
 
-    var extraHeaders = _extraHeaders ?? [];
+    var extraHeaders = this._extraHeaders ?? [];
 
     extraHeaders.add(
         'Contact: ${this._contact};expires=${this._expires}${this._extraContactParams}');
@@ -133,11 +133,15 @@ class Registrator {
     EventManager localEventHandlers = EventManager();
     localEventHandlers.on(EventOnRequestTimeout(),
         (EventOnRequestTimeout value) {
-      this._registrationFailure(UnHandledResponse(408, DartSIP_C.causes.REQUEST_TIMEOUT), DartSIP_C.causes.REQUEST_TIMEOUT);
+      this._registrationFailure(
+          UnHandledResponse(408, DartSIP_C.causes.REQUEST_TIMEOUT),
+          DartSIP_C.causes.REQUEST_TIMEOUT);
     });
     localEventHandlers.on(EventOnTransportError(),
         (EventOnTransportError value) {
-      this._registrationFailure(UnHandledResponse(500, DartSIP_C.causes.CONNECTION_ERROR), DartSIP_C.causes.CONNECTION_ERROR);
+      this._registrationFailure(
+          UnHandledResponse(500, DartSIP_C.causes.CONNECTION_ERROR),
+          DartSIP_C.causes.CONNECTION_ERROR);
     });
     localEventHandlers.on(EventOnAuthenticated(), (EventOnAuthenticated value) {
       this._cseq += 1;
@@ -274,7 +278,7 @@ class Registrator {
       this._registrationTimer = null;
     }
 
-    var extraHeaders = _extraHeaders ?? [];
+    var extraHeaders = this._extraHeaders ?? [];
 
     if (unregister_all) {
       extraHeaders.add('Contact: *${this._extraContactParams}');

--- a/lib/src/sip_ua_helper.dart
+++ b/lib/src/sip_ua_helper.dart
@@ -103,6 +103,9 @@ class SIPUAHelper extends EventManager {
     _settings.display_name = uaSettings.displayName;
     _settings.authorization_user = uaSettings.authorizationUser;
     _settings.user_agent = uaSettings.userAgent ?? DartSIP_C.USER_AGENT;
+    _settings.register_extra_headers = uaSettings.registerParams.extraHeaders;
+    _settings.register_extra_contact_params =
+        uaSettings.registerParams.extraContactParams;
 
     try {
       _ua = UA(_settings);
@@ -528,9 +531,20 @@ class WebSocketSettings {
   bool allowBadCertificate = false;
 }
 
+class RegisterParams {
+  /// Allow extra headers and Contact Params to be sent on REGISTER
+  /// Mainly used for RFC8599 Support
+  /// https://github.com/cloudwebrtc/dart-sip-ua/issues/89
+  Map<String, dynamic> extraHeaders = {};
+  Map<String, dynamic> extraContactParams = {};
+}
+
 class UaSettings {
   String webSocketUrl;
   WebSocketSettings webSocketSettings = WebSocketSettings();
+
+  /// Mainly used for RFC8599 Push Notification Support
+  RegisterParams registerParams = RegisterParams();
 
   /// `User Agent` field for sip message.
   String userAgent;


### PR DESCRIPTION
Allow Contact params and extra headers to be set for SIP REGISTER. Current use case for RFC8599 Push Notification support to pass Firebase Cloud Messaging Tokens and APNs Tokens in SIP registrations. Refs #89 