### PR TITLE
Add extended header support

### DIFF
--- a/lib/src/sip_ua_helper.dart
+++ b/lib/src/sip_ua_helper.dart
@@ -69,12 +69,16 @@ class SIPUAHelper extends EventManager {
   }
 
   Future<bool> call(String target,
-      {bool voiceonly = false, MediaStream mediaStream = null}) async {
+      {bool voiceonly = false,
+      MediaStream mediaStream = null,
+      List<String> headers = const []}) async {
     if (_ua != null && _ua.isConnected()) {
       Map<String, Object> options = buildCallOptions(voiceonly);
       if (mediaStream != null) {
         options['mediaStream'] = mediaStream;
       }
+      List<dynamic> extHeaders = options['extraHeaders'];
+      extHeaders.addAll(headers);
       _ua.call(target, options);
       return true;
     } else {
@@ -273,6 +277,7 @@ class SIPUAHelper extends EventManager {
 
     Map<String, Object> _defaultOptions = <String, dynamic>{
       'eventHandlers': handlers,
+      'extraHeaders': <dynamic>[],
       'pcConfig': <String, dynamic>{
         'sdpSemantics': 'unified-plan',
         'iceServers': _uaSettings.iceServers
@@ -391,6 +396,7 @@ class Call {
 
   String get id => _id;
   RTCPeerConnection get peerConnection => _session.connection;
+  RTCSession get session => _session;
   CallStateEnum state;
 
   void answer(Map<String, Object> options, {MediaStream mediaStream = null}) {


### PR DESCRIPTION
Add extended header support, in order to carry custom information when calling

This is an example code to get the header content
```
  static Map<String, dynamic> getHeaders(Call call) {
    // IncomingRequest/OutgoingRequest
    var request = call.session.request;
    if (request is IncomingRequest) {
      return request.headers;
    } else if (request is OutgoingRequest) {
      return GUIUtils.parseHeaders(request.extraHeaders);
    }
    return {};
  }
```