### PR TITLE
fix: persist 'ws_uri' in _saveSettings to enable proper registration

### DIFF
--- a/example/lib/src/register.dart
+++ b/example/lib/src/register.dart
@@ -127,6 +127,13 @@ class _MyRegisterWidget extends State<RegisterWidget>
     _saveSettings();
 
        currentUser.register(SipUser(
+        wsUrl: _wsUriController.text,  
+        //this is the websocket url which was missing in the original code hence it
+        //was showing null in the register method of sip_user_cubit.dart and always
+        //redirected to 'wss://tryit.jssip.net:10443', present inside sip_ua_helper.dart
+        //161: uaSettings.webSocketUrl ?? 'wss://tryit.jssip.net:10443',
+        //this will help people trying out the example to register with the correct url
+        //without changing the code in sip_ua_helper.dart
         selectedTransport: _selectedTransport,
         wsExtraHeaders: _wsExtraHeaders,
         sipUri: _sipUriController.text,


### PR DESCRIPTION
Added a missing line which enabled updating the websocket url as entered by the user in the textfield. 

It was missing in the original code which prevented setting up connection to the entered url and redirected to the one mentioned in the sip_ua_helper.dart file as 'wss://tryit.jssip.net:10443'.

![Screenshot 2025-04-25 113616](https://github.com/user-attachments/assets/82f339f7-af01-4a86-bd0b-1ef672268ba4)

