### PR TITLE
docs(readme): replace pub.dartlang.org with pub.dev; normalize macOS; update Flutter docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dart-sip-ua
 
-[![Financial Contributors on Open Collective](https://opencollective.com/flutter-webrtc/all/badge.svg?label=financial+contributors)](https://opencollective.com/flutter-webrtc) [![pub package](https://img.shields.io/pub/v/sip_ua.svg)](https://pub.dartlang.org/packages/sip_ua)  [![slack](https://img.shields.io/badge/join-us%20on%20slack-gray.svg?longCache=true&logo=slack&colorB=brightgreen)](https://join.slack.com/t/flutterwebrtc/shared_invite/zt-q83o7y1s-FExGLWEvtkPKM8ku_F8cEQ)
+[![Financial Contributors on Open Collective](https://opencollective.com/flutter-webrtc/all/badge.svg?label=financial+contributors)](https://opencollective.com/flutter-webrtc) [![pub package](https://img.shields.io/pub/v/sip_ua.svg)](https://pub.dev/packages/sip_ua)  [![slack](https://img.shields.io/badge/join-us%20on%20slack-gray.svg?longCache=true&logo=slack&colorB=brightgreen)](https://join.slack.com/t/flutterwebrtc/shared_invite/zt-q83o7y1s-FExGLWEvtkPKM8ku_F8cEQ)
  
 A dart-lang version of the SIP UA stack, ported from [JsSIP](https://github.com/versatica/JsSIP).
 


### PR DESCRIPTION
Small documentation cleanup in README:
- Replace legacy `pub.dartlang.org` links with `pub.dev`
- Normalize platform spelling `MacOS` -> `macOS`
- Update `flutter.dev/docs/...` links to `docs.flutter.dev/...`

No code changes.