### PR TITLE
Fix WebSocket and _handleHangup for web platform

### DIFF
--- a/example/lib/src/callscreen.dart
+++ b/example/lib/src/callscreen.dart
@@ -214,7 +214,15 @@ class _MyCallScreenWidget extends State<CallScreenWidget>
   }
 
   void _handleHangup() {
-    call!.hangup({'status_code': 603});
+    if (kIsWeb) {
+      call!.session.terminate({
+        'status_code': 603, // Decline
+        'reason_phrase': 'Call ended by user',
+        'originator': 'local',
+      });
+    } else {
+      call!.hangup({'status_code': 603});
+    }
     _timer.cancel();
   }
 

--- a/lib/src/transports/websocket_web_impl.dart
+++ b/lib/src/transports/websocket_web_impl.dart
@@ -23,7 +23,7 @@ class SIPUAWebSocketImpl {
       required WebSocketSettings webSocketSettings}) async {
     logger.i('connect $_url, ${webSocketSettings.extraHeaders}, $protocols');
     try {
-      _socket = WebSocket(_url, 'sip');
+      _socket = WebSocket(_url, 'sip'.toJS);
       _socket!.onOpen.listen((Event e) {
         onOpen?.call();
       });


### PR DESCRIPTION
### Changes

- WebSocket now uses sip.toJS on web to work correctly with JavaScript.

- _handleHangup now handles web vs. other platforms differently: on web, it calls session.terminate; on other platforms, it calls hangup.


### Why

These changes prevent runtime errors on the web and ensure calls are ended properly on all platforms.