### PR TITLE
Fix: WebSocket and Hangup for web platform

### DIFF
--- a/example/lib/src/callscreen.dart
+++ b/example/lib/src/callscreen.dart
@@ -214,7 +214,11 @@ class _MyCallScreenWidget extends State<CallScreenWidget>
   }
 
   void _handleHangup() {
-    call!.hangup({'status_code': 603});
+    if (kIsWeb) {
+      call!.session.terminate({'status_code': 603});
+    } else {
+      call!.hangup({'status_code': 603});
+    }
     _timer.cancel();
   }
 

--- a/lib/src/transports/websocket_web_impl.dart
+++ b/lib/src/transports/websocket_web_impl.dart
@@ -23,7 +23,7 @@ class SIPUAWebSocketImpl {
       required WebSocketSettings webSocketSettings}) async {
     logger.i('connect $_url, ${webSocketSettings.extraHeaders}, $protocols');
     try {
-      _socket = WebSocket(_url, 'sip');
+      _socket = WebSocket(_url, 'sip'.toJS);
       _socket!.onOpen.listen((Event e) {
         onOpen?.call();
       });


### PR DESCRIPTION
### Changes:

- Updated WebSocket initialization to use sip.toJS on web for proper JavaScript compatibility.

- Modified _handleHangup to differentiate behavior by platform:

    - Web: calls session.terminate()

    -  Other platforms: calls hangup()

### Why:
These changes prevent runtime errors on web and ensure that calls are properly terminated across all platforms.