### PR TITLE
fix: add .toJS for WebSocket protocol parameter for Web platform

### DIFF
--- a/lib/src/transports/websocket_web_impl.dart
+++ b/lib/src/transports/websocket_web_impl.dart
@@ -23,7 +23,7 @@ class SIPUAWebSocketImpl {
       required WebSocketSettings webSocketSettings}) async {
     logger.i('connect $_url, ${webSocketSettings.extraHeaders}, $protocols');
     try {
-      _socket = WebSocket(_url, 'sip');
+      _socket = WebSocket(_url, 'sip'.toJS);
       _socket!.onOpen.listen((Event e) {
         onOpen?.call();
       });


### PR DESCRIPTION
Fixes WebSocket initialization on Web platform by converting the protocol string to JSAny type using .toJS extension. This is required for compatibility with Dart's new JS interop.

Without this fix, WebSocket constructor fails on Web with: 'The argument type String can't be assigned to the parameter type JSAny'