### PR TITLE
Export EventNewInfo in public API

### DIFF
--- a/lib/sip_ua.dart
+++ b/lib/sip_ua.dart
@@ -1,4 +1,5 @@
 export 'src/enums.dart';
+export 'src/event_manager/internal_events.dart' show EventNewInfo;
 export 'src/sip_message.dart';
 export 'src/sip_ua_helper.dart';
 export 'src/transport_type.dart';


### PR DESCRIPTION
# Export `EventNewInfo` from `sip_ua` public API

## Summary
- Expose `EventNewInfo` via the public `sip_ua.dart` export list so downstream apps can subscribe to SIP INFO events without `implementation_imports`.

## Why
- SIP INFO is delivered internally via `EventNewInfo`, but the type isn’t publicly exported.
- Apps currently must import `lib/src` to listen for INFO, which triggers `implementation_imports` warnings and is fragile.

## Changes
- Add a public export for `EventNewInfo` in `lib/sip_ua.dart`.

## Testing
- Not applicable; API export only.

## Notes
- This is backwards-compatible and does not change runtime behavior; it only exposes an existing event type.
