### PR TITLE
Add SipUaHelperListener onNewInfo callback

### DIFF
--- a/lib/src/sip_ua_helper.dart
+++ b/lib/src/sip_ua_helper.dart
@@ -351,6 +351,10 @@ class SIPUAHelper extends EventManager {
       });
     });
 
+    handlers.on(EventNewInfo(), (EventNewInfo event) {
+      _notifyInfoListeners(event);
+    });
+
     handlers.on(EventReInvite(), (EventReInvite event) {
       logger.d('Reinvite received in helper, notifying listeners');
       _notifyReInviteListeners(event);
@@ -518,6 +522,22 @@ class SIPUAHelper extends EventManager {
     List<SipUaHelperListener> listeners = _sipUaHelperListeners.toList();
     for (SipUaHelperListener listener in listeners) {
       listener.onNewNotify(Notify(request: event.request));
+    }
+  }
+
+  void _notifyInfoListeners(EventNewInfo event) {
+    // Copy to prevent concurrent modification exception
+    List<SipUaHelperListener> listeners = _sipUaHelperListeners.toList();
+    final IncomingRequest? request =
+        event.request is IncomingRequest ? event.request as IncomingRequest : null;
+    final SipInfo info = SipInfo(
+      contentType: event.info?.contentType ?? request?.getHeader('content-type'),
+      body: event.info?.body ?? request?.body,
+      request: request,
+      originator: event.originator,
+    );
+    for (SipUaHelperListener listener in listeners) {
+      listener.onNewInfo(info);
     }
   }
 }
@@ -775,11 +795,20 @@ abstract class SipUaHelperListener {
   void onNewMessage(SIPMessageRequest msg);
   void onNewNotify(Notify ntf);
   void onNewReinvite(ReInvite event);
+  void onNewInfo(SipInfo info) {}
 }
 
 class Notify {
   Notify({this.request});
   IncomingRequest? request;
+}
+
+class SipInfo {
+  SipInfo({this.contentType, this.body, this.request, this.originator});
+  String? contentType;
+  String? body;
+  IncomingRequest? request;
+  Originator? originator;
 }
 
 class ReInvite {


### PR DESCRIPTION
# Add `onNewInfo` callback to `SipUaHelperListener`

## Summary
- Surface SIP INFO events through the public `SipUaHelperListener` interface.
- Bridge internal `EventNewInfo` to a new `SipInfo` data object for consumers.

## Why
- INFO messages are currently only accessible via internal event handling.
- Exposing a listener callback lets apps handle SIP INFO using the same public callback pattern as other SIP events.

## Changes
- Register `EventNewInfo` in `SIPUAHelper.buildCallOptions`.
- Add `_notifyInfoListeners` to forward INFO events.
- Add `SipInfo` data holder and `onNewInfo` default method to `SipUaHelperListener`.

## Testing
- Not added (API wiring only).

## Notes
- Backwards compatible: existing listeners aren’t required to implement `onNewInfo`.
