### PR TITLE
use strict JS interop type

### DIFF
--- a/lib/src/transports/websocket_web_impl.dart
+++ b/lib/src/transports/websocket_web_impl.dart
@@ -23,7 +23,7 @@ class SIPUAWebSocketImpl {
       required WebSocketSettings webSocketSettings}) async {
     logger.i('connect $_url, ${webSocketSettings.extraHeaders}, $protocols');
     try {
-      _socket = WebSocket(_url, 'sip');
+      _socket = WebSocket(_url, 'sip'.toJS);
       _socket!.onOpen.listen((Event e) {
         onOpen?.call();
       });


### PR DESCRIPTION
Dart 3.4+/Flutter 3.22+ style uses strict JS interop types.
Older dart:html allowed passing String directly; the new web package requires explicit conversion to JS types.