### PR TITLE
Expose registrator accessor for runtime REGISTER customization

### DIFF
--- a/lib/src/sip_ua_helper.dart
+++ b/lib/src/sip_ua_helper.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter_webrtc/flutter_webrtc.dart';
 import 'package:logger/logger.dart';
 import 'package:sdp_transform/sdp_transform.dart' as sdp_transform;
+import 'package:sip_ua/src/registrator.dart';
 
 import 'package:sip_ua/src/uri.dart';
 import 'config.dart';
@@ -35,6 +36,7 @@ class SIPUAHelper extends EventManager {
   }
 
   UA? _ua;
+  Registrator? get registrator => _ua?.registratorInstance;
   Settings _settings = Settings();
   UaSettings? _uaSettings;
   final Map<String?, Call> _calls = <String?, Call>{};

--- a/lib/src/sip_ua_helper.dart
+++ b/lib/src/sip_ua_helper.dart
@@ -3,8 +3,8 @@ import 'dart:async';
 import 'package:flutter_webrtc/flutter_webrtc.dart';
 import 'package:logger/logger.dart';
 import 'package:sdp_transform/sdp_transform.dart' as sdp_transform;
-import 'package:sip_ua/src/registrator.dart';
 
+import 'package:sip_ua/src/registrator.dart';
 import 'package:sip_ua/src/uri.dart';
 import 'config.dart';
 import 'constants.dart' as DartSIP_C;

--- a/lib/src/transports/websocket_web_impl.dart
+++ b/lib/src/transports/websocket_web_impl.dart
@@ -1,8 +1,9 @@
 import 'dart:js_interop';
 
+import 'package:web/web.dart';
+
 import 'package:sip_ua/src/logger.dart';
 import 'package:sip_ua/src/sip_ua_helper.dart';
-import 'package:web/web.dart';
 
 typedef OnMessageCallback = void Function(dynamic msg);
 typedef OnCloseCallback = void Function(int? code, String? reason);

--- a/lib/src/ua.dart
+++ b/lib/src/ua.dart
@@ -78,6 +78,7 @@ class Contact {
  * @throws {TypeError} If no configuration is given.
  */
 class UA extends EventManager {
+  Registrator get registratorInstance => _registrator;
   UA(Settings configuration) {
     logger.d('new() [configuration:${configuration.toString()}]');
     // Load configuration.


### PR DESCRIPTION
### What this PR does

This PR exposes a safe accessor for the internal `Registrator` instance so that
applications can modify REGISTER / UNREGISTER extra Contact parameters at runtime
without forking the library.

### Why this is needed

Some applications (e.g. RFC8599 / push / call correlation use cases) need to add
dynamic Contact URI parameters **at the moment of REGISTER**, such as a runtime
UUID or call identifier.

Previously this was not possible without forking, because:
- `UA._registrator` was private
- `SIPUAHelper` had no way to reach the active registrator

### Changes

- Expose `registratorInstance` getter in `UA`
- Expose `registrator` getter in `SIPUAHelper`
- No behavior change, no breaking API changes

### Usage example

```dart
sipHelper.registrator?.setExtraContactParams({
  'calluuid': uuid,
});
sipHelper.register();
```

### Notes
- Fully backward compatible
- No changes to registration flow
- Minimal surface-area change (2 files, 3 LOC)
- This is an advanced-use feature intended for users familiar with the library
internals, as the underlying capability already existed but was not exposed via
the public plugin API.


### Thanks!

### Also feedback on additional test coverage or documentation improvements is welcome.
