### PR TITLE
fix: correct 2XX retransmission check in _sendReinvite and _sendUpdate

### DIFF
--- a/lib/src/rtc_session.dart
+++ b/lib/src/rtc_session.dart
@@ -2736,7 +2736,7 @@ class RTCSession extends EventManager implements Owner {
       sendRequest(SipMethod.ACK);
 
       // If it is a 2XX retransmission exit now.
-      if (succeeded != null) {
+      if (succeeded) {
         return;
       }
 
@@ -3011,7 +3011,7 @@ class RTCSession extends EventManager implements Owner {
       _handleSessionTimersInIncomingResponse(response);
 
       // If it is a 2XX retransmission exit now.
-      if (succeeded != null) {
+      if (succeeded) {
         return;
       }
 
@@ -3484,6 +3484,7 @@ class RTCSession extends EventManager implements Owner {
 
       for (StatsReport s in senderStats) {
         senderStat += ' ${s.timestamp} ${s.id} ${s.type}:\n';
+        // ignore: always_specify_types
         s.values.forEach((key, value) {
           senderStat += '  $key:  $value\n';
         });
@@ -3496,6 +3497,7 @@ class RTCSession extends EventManager implements Owner {
 
       for (StatsReport s in receiverStats) {
         receiverStat += ' ${s.timestamp} ${s.id} ${s.type}\n';
+        // ignore: always_specify_types
         s.values.forEach((key, value) {
           receiverStat += '  $key:  $value\n';
         });


### PR DESCRIPTION
  ## Problem
  `_sendReinvite()` and `_sendUpdate()` declare `bool succeeded = false`
  (non-nullable), then check `if (succeeded != null)` to detect 2XX
  retransmissions. Since a non-nullable `bool` is never `null`, this
  condition is always `true` — causing `onSucceeded` to return immediately
  before processing the SDP answer.

  This breaks re-INVITE and UPDATE flows: hold/unhold, call transfers,
  and mid-call media renegotiation silently fail because the SDP answer
  from the first (legitimate) 2XX response is never applied.

  ## Root cause
  Likely a leftover from the JavaScript (JsSIP) origin of the library,
  where `succeeded` could be `undefined`/`null`. In Dart's null-safe
  type system, `bool` is non-nullable so `!= null` is always `true`.

  ## Fix
  Changed `if (succeeded != null)` to `if (succeeded)` in both
  `_sendReinvite()` and `_sendUpdate()`. This correctly skips processing
  only on actual 2XX retransmissions (when `succeeded` has been set to
  `true` after the first successful response).

  Note: `_sendRefer()` already uses the correct `if (succeeded)` check.