### PR TITLE
Expose generated contact URI from SIPUAHelper

### DIFF
--- a/lib/src/sip_ua_helper.dart
+++ b/lib/src/sip_ua_helper.dart
@@ -68,6 +68,9 @@ class SIPUAHelper extends EventManager {
     return false;
   }
 
+  /// Contact URI generated for the User-Agent.
+  String? get contactUri => _ua?.contact?.uri?.toString();
+
   RegistrationState get registerState => _registerState;
 
   void stop() async {


### PR DESCRIPTION
## Summary

Expose the User-Agent generated Contact URI through `SIPUAHelper`.

Some consumers need the generated SIP Contact URI for external registration or routing coordination, but currently the generated Contact is only available through internal UA state.

## Change

Adds a nullable `contactUri` getter to `SIPUAHelper`:

```dart
String? get contactUri => _ua?.contact?.uri?.toString();