### PR TITLE
fix: contact uri dropped in config load

### DIFF
--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -77,192 +77,198 @@ class Settings {
 class Checks {
   Map<String, Null Function(Settings src, Settings? dst)> mandatory =
       <String, Null Function(Settings src, Settings? dst)>{
-    'sockets': (Settings src, Settings? dst) {
-      List<SIPUASocketInterface>? sockets = src.sockets;
+        'sockets': (Settings src, Settings? dst) {
+          List<SIPUASocketInterface>? sockets = src.sockets;
 
-      /* Allow defining sockets parameter as:
+          /* Allow defining sockets parameter as:
        *  Socket: socket
        *  List of Socket: [socket1, socket2]
        *  List of Objects: [{socket: socket1, weight:1}, {socket: Socket2, weight:0}]
        *  List of Objects and Socket: [{socket: socket1}, socket2]
        */
-      List<SIPUASocketInterface> copy = <SIPUASocketInterface>[];
-      if (sockets is List && sockets!.isNotEmpty) {
-        for (SIPUASocketInterface socket in sockets) {
-          copy.add(socket);
-        }
-      } else {
-        throw Exceptions.ConfigurationError('sockets', sockets);
-      }
+          List<SIPUASocketInterface> copy = <SIPUASocketInterface>[];
+          if (sockets is List && sockets!.isNotEmpty) {
+            for (SIPUASocketInterface socket in sockets) {
+              copy.add(socket);
+            }
+          } else {
+            throw Exceptions.ConfigurationError('sockets', sockets);
+          }
 
-      dst!.sockets = copy;
-    },
-    'uri': (Settings src, Settings? dst) {
-      if (src.uri == null && dst!.uri == null) {
-        throw Exceptions.ConfigurationError('uri', null);
-      }
-      URI uri = src.uri!;
-      if (!uri.toString().contains(RegExp(r'^sip:', caseSensitive: false))) {
-        uri.scheme = DartSIP_C.SIP;
-      }
-      dst!.uri = uri;
-    },
-    'transport_type': (Settings src, Settings? dst) {
-      dynamic transportType = src.transportType;
-      if (src.transportType == null && dst!.transportType == null) {
-        throw Exceptions.ConfigurationError('transport type', null);
-      }
-      dst!.transportType = transportType;
-    }
-  };
+          dst!.sockets = copy;
+        },
+        'uri': (Settings src, Settings? dst) {
+          if (src.uri == null && dst!.uri == null) {
+            throw Exceptions.ConfigurationError('uri', null);
+          }
+          URI uri = src.uri!;
+          if (!uri.toString().contains(
+            RegExp(r'^sip:', caseSensitive: false),
+          )) {
+            uri.scheme = DartSIP_C.SIP;
+          }
+          dst!.uri = uri;
+        },
+        'transport_type': (Settings src, Settings? dst) {
+          dynamic transportType = src.transportType;
+          if (src.transportType == null && dst!.transportType == null) {
+            throw Exceptions.ConfigurationError('transport type', null);
+          }
+          dst!.transportType = transportType;
+        },
+      };
   Map<String, Null Function(Settings src, Settings? dst)> optional =
       <String, Null Function(Settings src, Settings? dst)>{
-    'authorization_user': (Settings src, Settings? dst) {
-      String? authorization_user = src.authorization_user;
-      if (authorization_user == null) return;
-      if (Grammar.parse('"$authorization_user"', 'quoted_string') == -1) {
-        return;
-      } else {
-        dst!.authorization_user = authorization_user;
-      }
-    },
-    'user_agent': (Settings src, Settings? dst) {
-      String user_agent = src.user_agent;
-      if (user_agent == null) return;
-      dst!.user_agent = user_agent;
-    },
-    'connection_recovery_max_interval': (Settings src, Settings? dst) {
-      int connection_recovery_max_interval =
-          src.connection_recovery_max_interval;
-      if (connection_recovery_max_interval == null) return;
-      if (connection_recovery_max_interval > 0) {
-        dst!.connection_recovery_max_interval =
-            connection_recovery_max_interval;
-      }
-    },
-    'connection_recovery_min_interval': (Settings src, Settings? dst) {
-      int connection_recovery_min_interval =
-          src.connection_recovery_min_interval;
-      if (connection_recovery_min_interval == null) return;
-      if (connection_recovery_min_interval > 0) {
-        dst!.connection_recovery_min_interval =
-            connection_recovery_min_interval;
-      }
-    },
-    'contact_uri': (Settings src, Settings? dst) {
-      dynamic contact_uri = src.contact_uri;
-      if (contact_uri == null) return;
-      if (contact_uri is String) {
-        dynamic uri = Grammar.parse(contact_uri, 'SIP_URI');
-        if (uri != -1) {
-          dst!.contact_uri = uri;
-        }
-      }
-    },
-    'display_name': (Settings src, Settings? dst) {
-      String? display_name = src.display_name;
-      if (display_name == null) return;
-      dst!.display_name = display_name;
-    },
-    'instance_id': (Settings src, Settings? dst) {
-      String? instance_id = src.instance_id;
-      if (instance_id == null) return;
-      if (instance_id.contains(RegExp(r'^uuid:', caseSensitive: false))) {
-        instance_id = instance_id.substring(5);
-      }
-      if (Grammar.parse(instance_id, 'uuid') == -1) {
-        return;
-      } else {
-        dst!.instance_id = instance_id;
-      }
-    },
-    'no_answer_timeout': (Settings src, Settings? dst) {
-      int no_answer_timeout = src.no_answer_timeout;
-      if (no_answer_timeout == null) return;
-      if (no_answer_timeout > 0) {
-        dst!.no_answer_timeout = no_answer_timeout;
-      }
-    },
-    'session_timers': (Settings src, Settings? dst) {
-      bool session_timers = src.session_timers;
-      if (session_timers == null) return;
-      dst!.session_timers = session_timers;
-    },
-    'session_timers_refresh_method': (Settings src, Settings? dst) {
-      SipMethod method = src.session_timers_refresh_method;
-      if (method == SipMethod.INVITE || method == SipMethod.UPDATE) {
-        dst!.session_timers_refresh_method = method;
-      }
-    },
-    'password': (Settings src, Settings? dst) {
-      String? password = src.password;
-      if (password == null) return;
-      dst!.password = password.toString();
-    },
-    'realm': (Settings src, Settings? dst) {
-      String? realm = src.realm;
-      if (realm == null) return;
-      dst!.realm = realm.toString();
-    },
-    'ha1': (Settings src, Settings? dst) {
-      String? ha1 = src.ha1;
-      if (ha1 == null) return;
-      dst!.ha1 = ha1.toString();
-    },
-    'register': (Settings src, Settings? dst) {
-      bool? register = src.register;
-      if (register == null) return;
-      dst!.register = register;
-    },
-    'register_expires': (Settings src, Settings? dst) {
-      int? register_expires = src.register_expires;
-      if (register_expires == null) return;
-      if (register_expires > 0) {
-        dst!.register_expires = register_expires;
-      }
-    },
-    'registrar_server': (Settings src, Settings? dst) {
-      dynamic registrar_server = src.registrar_server;
-      if (registrar_server == null) return;
-      if (!registrar_server.contains(RegExp(r'^sip:', caseSensitive: false))) {
-        registrar_server = '${DartSIP_C.SIP}:$registrar_server';
-      }
-      dynamic parsed = URI.parse(registrar_server);
-      if (parsed == null || parsed.user != null) {
-        return;
-      } else {
-        dst!.registrar_server = parsed;
-      }
-    },
-    'register_extra_headers': (Settings src, Settings? dst) {
-      List<String>? register_extra_headers = src.register_extra_headers;
-      if (register_extra_headers == null) return;
-      dst?.register_extra_headers = register_extra_headers;
-    },
-    'register_extra_contact_uri_params': (Settings src, Settings? dst) {
-      Map<String, dynamic>? register_extra_contact_uri_params =
-          src.register_extra_contact_uri_params;
-      if (register_extra_contact_uri_params == null) return;
-      dst!.register_extra_contact_uri_params =
-          register_extra_contact_uri_params;
-    },
-    'use_preloaded_route': (Settings src, Settings? dst) {
-      bool use_preloaded_route = src.use_preloaded_route;
-      if (use_preloaded_route == null) return;
-      dst!.use_preloaded_route = use_preloaded_route;
-    },
-    'dtmf_mode': (Settings src, Settings? dst) {
-      DtmfMode dtmf_mode = src.dtmf_mode;
-      if (dtmf_mode == null) return;
-      dst!.dtmf_mode = dtmf_mode;
-    },
-    'ice_gathering_timeout': (Settings src, Settings? dst) {
-      dst!.ice_gathering_timeout = src.ice_gathering_timeout;
-    },
-    'log_call_statistics': (Settings src, Settings? dst) {
-      dst!.log_call_statistics = src.log_call_statistics;
-    }
-  };
+        'authorization_user': (Settings src, Settings? dst) {
+          String? authorization_user = src.authorization_user;
+          if (authorization_user == null) return;
+          if (Grammar.parse('"$authorization_user"', 'quoted_string') == -1) {
+            return;
+          } else {
+            dst!.authorization_user = authorization_user;
+          }
+        },
+        'user_agent': (Settings src, Settings? dst) {
+          String user_agent = src.user_agent;
+          if (user_agent == null) return;
+          dst!.user_agent = user_agent;
+        },
+        'connection_recovery_max_interval': (Settings src, Settings? dst) {
+          int connection_recovery_max_interval =
+              src.connection_recovery_max_interval;
+          if (connection_recovery_max_interval == null) return;
+          if (connection_recovery_max_interval > 0) {
+            dst!.connection_recovery_max_interval =
+                connection_recovery_max_interval;
+          }
+        },
+        'connection_recovery_min_interval': (Settings src, Settings? dst) {
+          int connection_recovery_min_interval =
+              src.connection_recovery_min_interval;
+          if (connection_recovery_min_interval == null) return;
+          if (connection_recovery_min_interval > 0) {
+            dst!.connection_recovery_min_interval =
+                connection_recovery_min_interval;
+          }
+        },
+        'contact_uri': (Settings src, Settings? dst) {
+          dynamic contact_uri = src.contact_uri;
+          if (contact_uri == null) return;
+          if (contact_uri is String) {
+            dynamic uri = Grammar.parse(contact_uri, 'SIP_URI');
+            if (uri != -1) {
+              dst!.contact_uri = uri;
+            }
+          } else if (contact_uri is URI) {
+            dst!.contact_uri = contact_uri;
+          }
+        },
+        'display_name': (Settings src, Settings? dst) {
+          String? display_name = src.display_name;
+          if (display_name == null) return;
+          dst!.display_name = display_name;
+        },
+        'instance_id': (Settings src, Settings? dst) {
+          String? instance_id = src.instance_id;
+          if (instance_id == null) return;
+          if (instance_id.contains(RegExp(r'^uuid:', caseSensitive: false))) {
+            instance_id = instance_id.substring(5);
+          }
+          if (Grammar.parse(instance_id, 'uuid') == -1) {
+            return;
+          } else {
+            dst!.instance_id = instance_id;
+          }
+        },
+        'no_answer_timeout': (Settings src, Settings? dst) {
+          int no_answer_timeout = src.no_answer_timeout;
+          if (no_answer_timeout == null) return;
+          if (no_answer_timeout > 0) {
+            dst!.no_answer_timeout = no_answer_timeout;
+          }
+        },
+        'session_timers': (Settings src, Settings? dst) {
+          bool session_timers = src.session_timers;
+          if (session_timers == null) return;
+          dst!.session_timers = session_timers;
+        },
+        'session_timers_refresh_method': (Settings src, Settings? dst) {
+          SipMethod method = src.session_timers_refresh_method;
+          if (method == SipMethod.INVITE || method == SipMethod.UPDATE) {
+            dst!.session_timers_refresh_method = method;
+          }
+        },
+        'password': (Settings src, Settings? dst) {
+          String? password = src.password;
+          if (password == null) return;
+          dst!.password = password.toString();
+        },
+        'realm': (Settings src, Settings? dst) {
+          String? realm = src.realm;
+          if (realm == null) return;
+          dst!.realm = realm.toString();
+        },
+        'ha1': (Settings src, Settings? dst) {
+          String? ha1 = src.ha1;
+          if (ha1 == null) return;
+          dst!.ha1 = ha1.toString();
+        },
+        'register': (Settings src, Settings? dst) {
+          bool? register = src.register;
+          if (register == null) return;
+          dst!.register = register;
+        },
+        'register_expires': (Settings src, Settings? dst) {
+          int? register_expires = src.register_expires;
+          if (register_expires == null) return;
+          if (register_expires > 0) {
+            dst!.register_expires = register_expires;
+          }
+        },
+        'registrar_server': (Settings src, Settings? dst) {
+          dynamic registrar_server = src.registrar_server;
+          if (registrar_server == null) return;
+          if (!registrar_server.contains(
+            RegExp(r'^sip:', caseSensitive: false),
+          )) {
+            registrar_server = '${DartSIP_C.SIP}:$registrar_server';
+          }
+          dynamic parsed = URI.parse(registrar_server);
+          if (parsed == null || parsed.user != null) {
+            return;
+          } else {
+            dst!.registrar_server = parsed;
+          }
+        },
+        'register_extra_headers': (Settings src, Settings? dst) {
+          List<String>? register_extra_headers = src.register_extra_headers;
+          if (register_extra_headers == null) return;
+          dst?.register_extra_headers = register_extra_headers;
+        },
+        'register_extra_contact_uri_params': (Settings src, Settings? dst) {
+          Map<String, dynamic>? register_extra_contact_uri_params =
+              src.register_extra_contact_uri_params;
+          if (register_extra_contact_uri_params == null) return;
+          dst!.register_extra_contact_uri_params =
+              register_extra_contact_uri_params;
+        },
+        'use_preloaded_route': (Settings src, Settings? dst) {
+          bool use_preloaded_route = src.use_preloaded_route;
+          if (use_preloaded_route == null) return;
+          dst!.use_preloaded_route = use_preloaded_route;
+        },
+        'dtmf_mode': (Settings src, Settings? dst) {
+          DtmfMode dtmf_mode = src.dtmf_mode;
+          if (dtmf_mode == null) return;
+          dst!.dtmf_mode = dtmf_mode;
+        },
+        'ice_gathering_timeout': (Settings src, Settings? dst) {
+          dst!.ice_gathering_timeout = src.ice_gathering_timeout;
+        },
+        'log_call_statistics': (Settings src, Settings? dst) {
+          dst!.log_call_statistics = src.log_call_statistics;
+        },
+      };
 }
 
 final Checks checks = Checks();
@@ -270,15 +276,19 @@ final Checks checks = Checks();
 void load(Settings src, Settings? dst) {
   try {
     // Check Mandatory parameters.
-    checks.mandatory
-        .forEach((String parameter, Null Function(Settings, Settings?) fun) {
+    checks.mandatory.forEach((
+      String parameter,
+      Null Function(Settings, Settings?) fun,
+    ) {
       logger.i('Check mandatory parameter => $parameter.');
       fun(src, dst);
     });
 
     // Check Optional parameters.
-    checks.optional
-        .forEach((String parameter, Null Function(Settings, Settings?) fun) {
+    checks.optional.forEach((
+      String parameter,
+      Null Function(Settings, Settings?) fun,
+    ) {
       logger.d('Check optional parameter => $parameter.');
       fun(src, dst);
     });

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -77,198 +77,194 @@ class Settings {
 class Checks {
   Map<String, Null Function(Settings src, Settings? dst)> mandatory =
       <String, Null Function(Settings src, Settings? dst)>{
-        'sockets': (Settings src, Settings? dst) {
-          List<SIPUASocketInterface>? sockets = src.sockets;
+    'sockets': (Settings src, Settings? dst) {
+      List<SIPUASocketInterface>? sockets = src.sockets;
 
-          /* Allow defining sockets parameter as:
+      /* Allow defining sockets parameter as:
        *  Socket: socket
        *  List of Socket: [socket1, socket2]
        *  List of Objects: [{socket: socket1, weight:1}, {socket: Socket2, weight:0}]
        *  List of Objects and Socket: [{socket: socket1}, socket2]
        */
-          List<SIPUASocketInterface> copy = <SIPUASocketInterface>[];
-          if (sockets is List && sockets!.isNotEmpty) {
-            for (SIPUASocketInterface socket in sockets) {
-              copy.add(socket);
-            }
-          } else {
-            throw Exceptions.ConfigurationError('sockets', sockets);
-          }
+      List<SIPUASocketInterface> copy = <SIPUASocketInterface>[];
+      if (sockets is List && sockets!.isNotEmpty) {
+        for (SIPUASocketInterface socket in sockets) {
+          copy.add(socket);
+        }
+      } else {
+        throw Exceptions.ConfigurationError('sockets', sockets);
+      }
 
-          dst!.sockets = copy;
-        },
-        'uri': (Settings src, Settings? dst) {
-          if (src.uri == null && dst!.uri == null) {
-            throw Exceptions.ConfigurationError('uri', null);
-          }
-          URI uri = src.uri!;
-          if (!uri.toString().contains(
-            RegExp(r'^sip:', caseSensitive: false),
-          )) {
-            uri.scheme = DartSIP_C.SIP;
-          }
-          dst!.uri = uri;
-        },
-        'transport_type': (Settings src, Settings? dst) {
-          dynamic transportType = src.transportType;
-          if (src.transportType == null && dst!.transportType == null) {
-            throw Exceptions.ConfigurationError('transport type', null);
-          }
-          dst!.transportType = transportType;
-        },
-      };
+      dst!.sockets = copy;
+    },
+    'uri': (Settings src, Settings? dst) {
+      if (src.uri == null && dst!.uri == null) {
+        throw Exceptions.ConfigurationError('uri', null);
+      }
+      URI uri = src.uri!;
+      if (!uri.toString().contains(RegExp(r'^sip:', caseSensitive: false))) {
+        uri.scheme = DartSIP_C.SIP;
+      }
+      dst!.uri = uri;
+    },
+    'transport_type': (Settings src, Settings? dst) {
+      dynamic transportType = src.transportType;
+      if (src.transportType == null && dst!.transportType == null) {
+        throw Exceptions.ConfigurationError('transport type', null);
+      }
+      dst!.transportType = transportType;
+    }
+  };
   Map<String, Null Function(Settings src, Settings? dst)> optional =
       <String, Null Function(Settings src, Settings? dst)>{
-        'authorization_user': (Settings src, Settings? dst) {
-          String? authorization_user = src.authorization_user;
-          if (authorization_user == null) return;
-          if (Grammar.parse('"$authorization_user"', 'quoted_string') == -1) {
-            return;
-          } else {
-            dst!.authorization_user = authorization_user;
-          }
-        },
-        'user_agent': (Settings src, Settings? dst) {
-          String user_agent = src.user_agent;
-          if (user_agent == null) return;
-          dst!.user_agent = user_agent;
-        },
-        'connection_recovery_max_interval': (Settings src, Settings? dst) {
-          int connection_recovery_max_interval =
-              src.connection_recovery_max_interval;
-          if (connection_recovery_max_interval == null) return;
-          if (connection_recovery_max_interval > 0) {
-            dst!.connection_recovery_max_interval =
-                connection_recovery_max_interval;
-          }
-        },
-        'connection_recovery_min_interval': (Settings src, Settings? dst) {
-          int connection_recovery_min_interval =
-              src.connection_recovery_min_interval;
-          if (connection_recovery_min_interval == null) return;
-          if (connection_recovery_min_interval > 0) {
-            dst!.connection_recovery_min_interval =
-                connection_recovery_min_interval;
-          }
-        },
-        'contact_uri': (Settings src, Settings? dst) {
-          dynamic contact_uri = src.contact_uri;
-          if (contact_uri == null) return;
-          if (contact_uri is String) {
-            dynamic uri = Grammar.parse(contact_uri, 'SIP_URI');
-            if (uri != -1) {
-              dst!.contact_uri = uri;
-            }
-          } else if (contact_uri is URI) {
-            dst!.contact_uri = contact_uri;
-          }
-        },
-        'display_name': (Settings src, Settings? dst) {
-          String? display_name = src.display_name;
-          if (display_name == null) return;
-          dst!.display_name = display_name;
-        },
-        'instance_id': (Settings src, Settings? dst) {
-          String? instance_id = src.instance_id;
-          if (instance_id == null) return;
-          if (instance_id.contains(RegExp(r'^uuid:', caseSensitive: false))) {
-            instance_id = instance_id.substring(5);
-          }
-          if (Grammar.parse(instance_id, 'uuid') == -1) {
-            return;
-          } else {
-            dst!.instance_id = instance_id;
-          }
-        },
-        'no_answer_timeout': (Settings src, Settings? dst) {
-          int no_answer_timeout = src.no_answer_timeout;
-          if (no_answer_timeout == null) return;
-          if (no_answer_timeout > 0) {
-            dst!.no_answer_timeout = no_answer_timeout;
-          }
-        },
-        'session_timers': (Settings src, Settings? dst) {
-          bool session_timers = src.session_timers;
-          if (session_timers == null) return;
-          dst!.session_timers = session_timers;
-        },
-        'session_timers_refresh_method': (Settings src, Settings? dst) {
-          SipMethod method = src.session_timers_refresh_method;
-          if (method == SipMethod.INVITE || method == SipMethod.UPDATE) {
-            dst!.session_timers_refresh_method = method;
-          }
-        },
-        'password': (Settings src, Settings? dst) {
-          String? password = src.password;
-          if (password == null) return;
-          dst!.password = password.toString();
-        },
-        'realm': (Settings src, Settings? dst) {
-          String? realm = src.realm;
-          if (realm == null) return;
-          dst!.realm = realm.toString();
-        },
-        'ha1': (Settings src, Settings? dst) {
-          String? ha1 = src.ha1;
-          if (ha1 == null) return;
-          dst!.ha1 = ha1.toString();
-        },
-        'register': (Settings src, Settings? dst) {
-          bool? register = src.register;
-          if (register == null) return;
-          dst!.register = register;
-        },
-        'register_expires': (Settings src, Settings? dst) {
-          int? register_expires = src.register_expires;
-          if (register_expires == null) return;
-          if (register_expires > 0) {
-            dst!.register_expires = register_expires;
-          }
-        },
-        'registrar_server': (Settings src, Settings? dst) {
-          dynamic registrar_server = src.registrar_server;
-          if (registrar_server == null) return;
-          if (!registrar_server.contains(
-            RegExp(r'^sip:', caseSensitive: false),
-          )) {
-            registrar_server = '${DartSIP_C.SIP}:$registrar_server';
-          }
-          dynamic parsed = URI.parse(registrar_server);
-          if (parsed == null || parsed.user != null) {
-            return;
-          } else {
-            dst!.registrar_server = parsed;
-          }
-        },
-        'register_extra_headers': (Settings src, Settings? dst) {
-          List<String>? register_extra_headers = src.register_extra_headers;
-          if (register_extra_headers == null) return;
-          dst?.register_extra_headers = register_extra_headers;
-        },
-        'register_extra_contact_uri_params': (Settings src, Settings? dst) {
-          Map<String, dynamic>? register_extra_contact_uri_params =
-              src.register_extra_contact_uri_params;
-          if (register_extra_contact_uri_params == null) return;
-          dst!.register_extra_contact_uri_params =
-              register_extra_contact_uri_params;
-        },
-        'use_preloaded_route': (Settings src, Settings? dst) {
-          bool use_preloaded_route = src.use_preloaded_route;
-          if (use_preloaded_route == null) return;
-          dst!.use_preloaded_route = use_preloaded_route;
-        },
-        'dtmf_mode': (Settings src, Settings? dst) {
-          DtmfMode dtmf_mode = src.dtmf_mode;
-          if (dtmf_mode == null) return;
-          dst!.dtmf_mode = dtmf_mode;
-        },
-        'ice_gathering_timeout': (Settings src, Settings? dst) {
-          dst!.ice_gathering_timeout = src.ice_gathering_timeout;
-        },
-        'log_call_statistics': (Settings src, Settings? dst) {
-          dst!.log_call_statistics = src.log_call_statistics;
-        },
-      };
+    'authorization_user': (Settings src, Settings? dst) {
+      String? authorization_user = src.authorization_user;
+      if (authorization_user == null) return;
+      if (Grammar.parse('"$authorization_user"', 'quoted_string') == -1) {
+        return;
+      } else {
+        dst!.authorization_user = authorization_user;
+      }
+    },
+    'user_agent': (Settings src, Settings? dst) {
+      String user_agent = src.user_agent;
+      if (user_agent == null) return;
+      dst!.user_agent = user_agent;
+    },
+    'connection_recovery_max_interval': (Settings src, Settings? dst) {
+      int connection_recovery_max_interval =
+          src.connection_recovery_max_interval;
+      if (connection_recovery_max_interval == null) return;
+      if (connection_recovery_max_interval > 0) {
+        dst!.connection_recovery_max_interval =
+            connection_recovery_max_interval;
+      }
+    },
+    'connection_recovery_min_interval': (Settings src, Settings? dst) {
+      int connection_recovery_min_interval =
+          src.connection_recovery_min_interval;
+      if (connection_recovery_min_interval == null) return;
+      if (connection_recovery_min_interval > 0) {
+        dst!.connection_recovery_min_interval =
+            connection_recovery_min_interval;
+      }
+    },
+    'contact_uri': (Settings src, Settings? dst) {
+      dynamic contact_uri = src.contact_uri;
+      if (contact_uri == null) return;
+      if (contact_uri is String) {
+        dynamic uri = Grammar.parse(contact_uri, 'SIP_URI');
+        if (uri != -1) {
+          dst!.contact_uri = uri;
+        }
+      } else if (contact_uri is URI) {
+        dst!.contact_uri = contact_uri;
+      }
+    },
+    'display_name': (Settings src, Settings? dst) {
+      String? display_name = src.display_name;
+      if (display_name == null) return;
+      dst!.display_name = display_name;
+    },
+    'instance_id': (Settings src, Settings? dst) {
+      String? instance_id = src.instance_id;
+      if (instance_id == null) return;
+      if (instance_id.contains(RegExp(r'^uuid:', caseSensitive: false))) {
+        instance_id = instance_id.substring(5);
+      }
+      if (Grammar.parse(instance_id, 'uuid') == -1) {
+        return;
+      } else {
+        dst!.instance_id = instance_id;
+      }
+    },
+    'no_answer_timeout': (Settings src, Settings? dst) {
+      int no_answer_timeout = src.no_answer_timeout;
+      if (no_answer_timeout == null) return;
+      if (no_answer_timeout > 0) {
+        dst!.no_answer_timeout = no_answer_timeout;
+      }
+    },
+    'session_timers': (Settings src, Settings? dst) {
+      bool session_timers = src.session_timers;
+      if (session_timers == null) return;
+      dst!.session_timers = session_timers;
+    },
+    'session_timers_refresh_method': (Settings src, Settings? dst) {
+      SipMethod method = src.session_timers_refresh_method;
+      if (method == SipMethod.INVITE || method == SipMethod.UPDATE) {
+        dst!.session_timers_refresh_method = method;
+      }
+    },
+    'password': (Settings src, Settings? dst) {
+      String? password = src.password;
+      if (password == null) return;
+      dst!.password = password.toString();
+    },
+    'realm': (Settings src, Settings? dst) {
+      String? realm = src.realm;
+      if (realm == null) return;
+      dst!.realm = realm.toString();
+    },
+    'ha1': (Settings src, Settings? dst) {
+      String? ha1 = src.ha1;
+      if (ha1 == null) return;
+      dst!.ha1 = ha1.toString();
+    },
+    'register': (Settings src, Settings? dst) {
+      bool? register = src.register;
+      if (register == null) return;
+      dst!.register = register;
+    },
+    'register_expires': (Settings src, Settings? dst) {
+      int? register_expires = src.register_expires;
+      if (register_expires == null) return;
+      if (register_expires > 0) {
+        dst!.register_expires = register_expires;
+      }
+    },
+    'registrar_server': (Settings src, Settings? dst) {
+      dynamic registrar_server = src.registrar_server;
+      if (registrar_server == null) return;
+      if (!registrar_server.contains(RegExp(r'^sip:', caseSensitive: false))) {
+        registrar_server = '${DartSIP_C.SIP}:$registrar_server';
+      }
+      dynamic parsed = URI.parse(registrar_server);
+      if (parsed == null || parsed.user != null) {
+        return;
+      } else {
+        dst!.registrar_server = parsed;
+      }
+    },
+    'register_extra_headers': (Settings src, Settings? dst) {
+      List<String>? register_extra_headers = src.register_extra_headers;
+      if (register_extra_headers == null) return;
+      dst?.register_extra_headers = register_extra_headers;
+    },
+    'register_extra_contact_uri_params': (Settings src, Settings? dst) {
+      Map<String, dynamic>? register_extra_contact_uri_params =
+          src.register_extra_contact_uri_params;
+      if (register_extra_contact_uri_params == null) return;
+      dst!.register_extra_contact_uri_params =
+          register_extra_contact_uri_params;
+    },
+    'use_preloaded_route': (Settings src, Settings? dst) {
+      bool use_preloaded_route = src.use_preloaded_route;
+      if (use_preloaded_route == null) return;
+      dst!.use_preloaded_route = use_preloaded_route;
+    },
+    'dtmf_mode': (Settings src, Settings? dst) {
+      DtmfMode dtmf_mode = src.dtmf_mode;
+      if (dtmf_mode == null) return;
+      dst!.dtmf_mode = dtmf_mode;
+    },
+    'ice_gathering_timeout': (Settings src, Settings? dst) {
+      dst!.ice_gathering_timeout = src.ice_gathering_timeout;
+    },
+    'log_call_statistics': (Settings src, Settings? dst) {
+      dst!.log_call_statistics = src.log_call_statistics;
+    }
+  };
 }
 
 final Checks checks = Checks();
@@ -276,19 +272,15 @@ final Checks checks = Checks();
 void load(Settings src, Settings? dst) {
   try {
     // Check Mandatory parameters.
-    checks.mandatory.forEach((
-      String parameter,
-      Null Function(Settings, Settings?) fun,
-    ) {
+    checks.mandatory
+        .forEach((String parameter, Null Function(Settings, Settings?) fun) {
       logger.i('Check mandatory parameter => $parameter.');
       fun(src, dst);
     });
 
     // Check Optional parameters.
-    checks.optional.forEach((
-      String parameter,
-      Null Function(Settings, Settings?) fun,
-    ) {
+    checks.optional
+        .forEach((String parameter, Null Function(Settings, Settings?) fun) {
       logger.d('Check optional parameter => $parameter.');
       fun(src, dst);
     });

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -150,16 +150,8 @@ class Checks {
       }
     },
     'contact_uri': (Settings src, Settings? dst) {
-      dynamic contact_uri = src.contact_uri;
-      if (contact_uri == null) return;
-      if (contact_uri is String) {
-        dynamic uri = Grammar.parse(contact_uri, 'SIP_URI');
-        if (uri != -1) {
-          dst!.contact_uri = uri;
-        }
-      } else if (contact_uri is URI) {
-        dst!.contact_uri = contact_uri;
-      }
+      if (src.contact_uri == null) return;
+      dst!.contact_uri = src.contact_uri;
     },
     'display_name': (Settings src, Settings? dst) {
       String? display_name = src.display_name;

--- a/lib/src/transports/websocket_web_impl.dart
+++ b/lib/src/transports/websocket_web_impl.dart
@@ -1,8 +1,9 @@
 import 'dart:js_interop';
 
+import 'package:web/web.dart';
+
 import 'package:sip_ua/src/logger.dart';
 import 'package:sip_ua/src/sip_ua_helper.dart';
-import 'package:web/web.dart';
 
 typedef OnMessageCallback = void Function(dynamic msg);
 typedef OnCloseCallback = void Function(int? code, String? reason);

--- a/test/all_test.dart
+++ b/test/all_test.dart
@@ -1,4 +1,5 @@
 import 'test_classes.dart' as Classes;
+import 'test_config.dart' as Config;
 import 'test_digest_authentication.dart' as DigestAuthentication;
 import 'test_normalize_target.dart' as NormalizeTarget;
 import 'test_parser.dart' as Parser;
@@ -6,6 +7,9 @@ import 'test_websocket.dart' as Websocket;
 
 void main() {
   for (Function func in Classes.testFunctions) {
+    func();
+  }
+  for (Function func in Config.testFunctions) {
     func();
   }
   for (Function func in Parser.testFunctions) {

--- a/test/test_config.dart
+++ b/test/test_config.dart
@@ -1,0 +1,35 @@
+import 'package:test/test.dart';
+
+import 'package:sip_ua/src/config.dart' as config;
+import 'package:sip_ua/src/utils.dart' as Utils;
+
+List<void Function()> testFunctions = <void Function()>[
+  () => test('Config: contact_uri given as URI is copied to settings', () {
+        // SIPUAHelper.start() converts UaSettings.contact_uri (String) into
+        // a URI via Utils.normalizeTarget before config.load runs, so the
+        // checker must accept URI instances.
+        config.Settings src = config.Settings()
+          ..contact_uri = Utils.normalizeTarget('sip:alice@example.com');
+        config.Settings dst = config.Settings();
+
+        config.checks.optional['contact_uri']!(src, dst);
+
+        expect(dst.contact_uri, isNotNull);
+        expect(dst.contact_uri!.user, 'alice');
+        expect(dst.contact_uri!.host, 'example.com');
+      }),
+  () => test('Config: null contact_uri stays null', () {
+        config.Settings src = config.Settings()..contact_uri = null;
+        config.Settings dst = config.Settings();
+
+        config.checks.optional['contact_uri']!(src, dst);
+
+        expect(dst.contact_uri, isNull);
+      })
+];
+
+void main() {
+  for (Function func in testFunctions) {
+    func();
+  }
+}


### PR DESCRIPTION
The following changes fix an issue where setting the `UaSettings.contact_uri` had no effect anymore.

In an older version of this library contact_uri was a String
```
'contact_uri': (Settings src, Settings? dst) {
      dynamic contact_uri = src.contact_uri;
      if (contact_uri == null) return;
      if (contact_uri is String) {
        dynamic uri = Grammar.parse(contact_uri, 'SIP_URI');
        if (uri != -1) {
          dst!.contact_uri = uri;
        }
      }
```

In the latest version `src.contact_uri` is an `URI?`. Therefore checking for a `String` doesn't make sense anymore and leads to `dst.contact_uri` being always null.
